### PR TITLE
Remove embedded and link serializer and use to_representation method

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,3 @@
+fail_on_violations: true
+python:
+  enabled: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: python
 python:
 - 3.6
-script: make test
+script: make test-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: python
+python:
+- 3.6
+script: make test

--- a/Makefile
+++ b/Makefile
@@ -24,5 +24,9 @@ install:  ## Install build dependencies (prerequisite for build)
 test: install  ## Run tests
 	@cd tests && python manage.py test $(test_method)
 
+test-ci:  ## Run tests
+	pip install $(requirements)
+	@cd tests && python manage.py test $(test_method)
+
 help:
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-25s\033[0m %s\n", $$1, $$2}'

--- a/drf_hal_json/serializers.py
+++ b/drf_hal_json/serializers.py
@@ -25,18 +25,18 @@ class HalModelSerializer(HyperlinkedModelSerializer):
         resp = defaultdict(dict)
 
         for field_name in self.link_field_names:
-            resp['_links'][field_name] = {'href': ret.pop(field_name)}
+            resp[LINKS_FIELD_NAME][field_name] = {'href': ret.pop(field_name)}
 
         for field_name in self.embedded_field_names:
             try:
                 # if a related resource is embedded, it should still
                 # get a link in the parent object
-                embed_self = ret[field_name].get('_links', {}).get('self')
+                embed_self = ret[field_name].get(LINKS_FIELD_NAME, {}).get(URL_FIELD_NAME)
                 if embed_self:
-                    resp['_links'][field_name] = embed_self
+                    resp[LINKS_FIELD_NAME][field_name] = embed_self
             except AttributeError:
                 pass
-            resp['_embedded'][field_name] = ret.pop(field_name)
+            resp[EMBEDDED_FIELD_NAME][field_name] = ret.pop(field_name)
 
         resp = {**resp, **ret}
         return resp

--- a/drf_hal_json/serializers.py
+++ b/drf_hal_json/serializers.py
@@ -13,7 +13,7 @@ class HalModelSerializer(HyperlinkedModelSerializer):
     Serializer for HAL representation of django models
     """
     serializer_related_field = HyperlinkedRelatedField
-    
+
     def __init__(self, instance=None, data=empty, **kwargs):
         super(HalModelSerializer, self).__init__(instance, data, **kwargs)
         self.nested_serializer_class = self.__class__
@@ -46,7 +46,7 @@ class HalModelSerializer(HyperlinkedModelSerializer):
 
         self.embedded_field_names = []
         self.link_field_names = []
-                
+
         for field_name, field in fields.items():
             if self._is_link_field(field):
                 self.link_field_names.append(field_name)

--- a/drf_hal_json/serializers.py
+++ b/drf_hal_json/serializers.py
@@ -31,7 +31,9 @@ class HalModelSerializer(HyperlinkedModelSerializer):
             try:
                 # if a related resource is embedded, it should still
                 # get a link in the parent object
-                embed_self = ret[field_name].get(LINKS_FIELD_NAME, {}).get(URL_FIELD_NAME)
+                embed_self = ret[field_name].get(
+                    LINKS_FIELD_NAME,
+                    {}).get(URL_FIELD_NAME)
                 if embed_self:
                     resp[LINKS_FIELD_NAME][field_name] = embed_self
             except AttributeError:

--- a/drf_hal_json/serializers.py
+++ b/drf_hal_json/serializers.py
@@ -1,5 +1,4 @@
-from collections import OrderedDict
-from copy import deepcopy
+from collections import defaultdict
 
 from rest_framework.fields import empty
 from rest_framework.relations import HyperlinkedIdentityField, HyperlinkedRelatedField, ManyRelatedField, RelatedField
@@ -9,105 +8,51 @@ from rest_framework.utils.field_mapping import get_nested_relation_kwargs
 from drf_hal_json import URL_FIELD_NAME, EMBEDDED_FIELD_NAME, LINKS_FIELD_NAME
 
 
-class HalEmbeddedSerializer(HyperlinkedModelSerializer):
-    pass
-
-
-class HalHyperlinkedModelSerializer(HyperlinkedModelSerializer):
-    def to_representation(self, instance):
-        representation = super(HyperlinkedModelSerializer, self).to_representation(instance)
-        hal_representation = OrderedDict((k, {'href': v}) for (k, v) in representation.items())
-        return hal_representation
-
-
 class HalModelSerializer(HyperlinkedModelSerializer):
     """
     Serializer for HAL representation of django models
     """
     serializer_related_field = HyperlinkedRelatedField
-    links_serializer_class = HalHyperlinkedModelSerializer
-    embedded_serializer_class = HalEmbeddedSerializer
-
+    
     def __init__(self, instance=None, data=empty, **kwargs):
         super(HalModelSerializer, self).__init__(instance, data, **kwargs)
         self.nested_serializer_class = self.__class__
         if data != empty and not LINKS_FIELD_NAME in data:
             data[LINKS_FIELD_NAME] = dict()  # put links in data, so that field validation does not fail
 
+    def to_representation(self, instance):
+        ret = super().to_representation(instance)
+        resp = defaultdict(dict)
+
+        for field_name in self.link_field_names:
+            resp['_links'][field_name] = {'href': ret.pop(field_name)}
+
+        for field_name in self.embedded_field_names:
+            try:
+                # if a related resource is embedded, it should still
+                # get a link in the parent object
+                embed_self = ret[field_name].get('_links', {}).get('self')
+                if embed_self:
+                    resp['_links'][field_name] = embed_self
+            except AttributeError:
+                pass
+            resp['_embedded'][field_name] = ret.pop(field_name)
+
+        resp = {**resp, **ret}
+        return resp
+
     def get_fields(self):
         fields = super(HalModelSerializer, self).get_fields()
 
-        embedded_field_names = list()
-        embedded_fields = {}
-        link_field_names = list()
-        link_fields = {}
-        resulting_fields = OrderedDict()
-        resulting_fields[LINKS_FIELD_NAME] = None  # assign it here because of the order -> links first
-
+        self.embedded_field_names = []
+        self.link_field_names = []
+                
         for field_name, field in fields.items():
             if self._is_link_field(field):
-                link_field_names.append(field_name)
-                link_fields[field_name] = field
+                self.link_field_names.append(field_name)
             elif self._is_embedded_field(field):
-                # if a related resource is embedded, it should still
-                # get a link in the parent object
-
-                try:
-                    link_fields[field_name] = deepcopy(field[LINKS_FIELD_NAME][URL_FIELD_NAME])
-                except TypeError:
-                    # List fields are not subscriptable -- we won't have links to an embedded field that is an array
-                    pass
-
-                embedded_field_names.append(field_name)
-                embedded_fields[field_name] = field
-            else:
-                resulting_fields[field_name] = field
-
-        links_serializer = self._get_links_serializer(self.Meta.model, link_field_names, link_fields)
-        if not links_serializer:
-            # in case the class is overridden and the inheriting class wants no links to be serialized, the links field is removed
-            del resulting_fields[LINKS_FIELD_NAME]
-        else:
-            resulting_fields[LINKS_FIELD_NAME] = links_serializer
-        if embedded_field_names:
-            resulting_fields[EMBEDDED_FIELD_NAME] = self._get_embedded_serializer(self.Meta.model,
-                                                                                  getattr(self.Meta, "depth", 0),
-                                                                                  embedded_field_names,
-                                                                                  embedded_fields)
-        return resulting_fields
-
-    def _get_links_serializer(self, model_cls, link_field_names, fields):
-        class HalNestedLinksSerializer(self.links_serializer_class):
-            serializer_related_field = self.serializer_related_field
-
-            class Meta:
-                model = model_cls
-                fields = link_field_names
-                extra_kwargs = getattr(self.Meta, 'extra_kwargs', {})
-
-            def get_fields(self):
-                return fields
-
-        return HalNestedLinksSerializer(instance=self.instance, source="*")
-
-    def _get_embedded_serializer(self, model_cls, embedded_depth, embedded_field_names, fields):
-        defined_nested_fields = getattr(self.Meta, "nested_fields", None)
-        nested_class = self.__class__
-
-        class HalNestedEmbeddedSerializer(self.embedded_serializer_class):
-            nested_serializer_class = nested_class
-
-            class Meta:
-                model = model_cls
-                fields = embedded_field_names
-                nested_fields = defined_nested_fields
-                depth = embedded_depth
-                extra_kwargs = getattr(self.Meta, 'extra_kwargs', {})
-
-            def get_fields(self):
-                return fields
-
-        return HalNestedEmbeddedSerializer(source="*")
+                self.embedded_field_names.append(field_name)
+        return fields
 
     @staticmethod
     def _is_link_field(field):


### PR DESCRIPTION
I was able to remove the intermediate serializers and build the HAL structure in the `to_representation` method instead. Wondering if that has any side effects 🤔 