### PR TITLE
Link arrays, optional title attribute for links

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ Request:
             }
         }
     }
+    
+### Link titles
+
+The optional `title` attribute is supported for link relations. If a serializer includes a field called
+`title`, it will not be serialized as part of the object itself. Instead, the `title` field enhances
+the link relation of the object.
 
 See the [test project][] for a complete Django project with more examples. 
 

--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ Request:
     
 ### Link titles
 
-The optional `title` attribute is supported for link relations. If a serializer includes a field called
-`title`, it will not be serialized as part of the object itself. Instead, the `title` field enhances
-the link relation of the object.
+The [optional `title` attribute][hal spec title] is supported for link relations. If a serializer 
+includes a field called `_link_title`, it will not be serialized as part of the object itself. 
+Instead, the field labels the link relation of the object.
 
 See the [test project][] for a complete Django project with more examples. 
 
@@ -89,3 +89,4 @@ $> make test
 ```
 
 [test project]: tests/
+[hal spec title]: https://tools.ietf.org/html/draft-kelly-json-hal-06#section-5.7

--- a/drf_hal_json/serializers.py
+++ b/drf_hal_json/serializers.py
@@ -27,8 +27,8 @@ class HalModelSerializer(HyperlinkedModelSerializer):
             val = ret.pop(field_name)
             if val is not None:
                 rel = {'href': val}
-                if 'title' in ret:
-                    rel['title'] = ret.pop('title')
+                if '_link_title' in ret:
+                    rel['title'] = ret.pop('_link_title')
                 resp[LINKS_FIELD_NAME][field_name] = rel
 
 

--- a/drf_hal_json/serializers.py
+++ b/drf_hal_json/serializers.py
@@ -26,19 +26,31 @@ class HalModelSerializer(HyperlinkedModelSerializer):
         for field_name in self.link_field_names:
             val = ret.pop(field_name)
             if val is not None:
-                resp[LINKS_FIELD_NAME][field_name] = {'href': val}
+                rel = {'href': val}
+                if 'title' in ret:
+                    rel['title'] = ret.pop('title')
+                resp[LINKS_FIELD_NAME][field_name] = rel
+
 
         for field_name in self.embedded_field_names:
+            # if a related resource is embedded, it should still
+            # get a link in the parent object
             try:
-                # if a related resource is embedded, it should still
-                # get a link in the parent object
-                embed_self = ret[field_name].get(
-                    LINKS_FIELD_NAME,
-                    {}).get(URL_FIELD_NAME)
-                if embed_self:
-                    resp[LINKS_FIELD_NAME][field_name] = embed_self
+                if type([]) == type(ret[field_name]):
+                    resp[LINKS_FIELD_NAME][field_name] = []
+                    for item in ret[field_name]:
+                        embed_self = item.get(LINKS_FIELD_NAME, {}).get(URL_FIELD_NAME)
+                        if embed_self:
+                            resp[LINKS_FIELD_NAME][field_name].append(embed_self)
+                else:
+                    embed_self = ret[field_name].get(
+                        LINKS_FIELD_NAME,
+                        {}).get(URL_FIELD_NAME)
+                    if embed_self:
+                        resp[LINKS_FIELD_NAME][field_name] = embed_self
             except AttributeError:
                 pass
+
             resp[EMBEDDED_FIELD_NAME][field_name] = ret.pop(field_name)
 
         resp = dict(resp, **ret)

--- a/drf_hal_json/serializers.py
+++ b/drf_hal_json/serializers.py
@@ -1,10 +1,10 @@
 from collections import defaultdict
+
+from drf_hal_json import EMBEDDED_FIELD_NAME, LINKS_FIELD_NAME, URL_FIELD_NAME
 from rest_framework.fields import empty
 from rest_framework.relations import HyperlinkedIdentityField, HyperlinkedRelatedField, ManyRelatedField, RelatedField
 from rest_framework.serializers import BaseSerializer, HyperlinkedModelSerializer
 from rest_framework.utils.field_mapping import get_nested_relation_kwargs
-
-from drf_hal_json import URL_FIELD_NAME, EMBEDDED_FIELD_NAME, LINKS_FIELD_NAME
 
 
 class HalModelSerializer(HyperlinkedModelSerializer):
@@ -19,6 +19,12 @@ class HalModelSerializer(HyperlinkedModelSerializer):
         if data != empty and not LINKS_FIELD_NAME in data:
             data[LINKS_FIELD_NAME] = dict()  # put links in data, so that field validation does not fail
 
+    def _get_url(self, item):
+        try:
+            return item.get(LINKS_FIELD_NAME, {}).get(URL_FIELD_NAME)
+        except AttributeError:
+            return None
+
     def to_representation(self, instance):
         ret = super().to_representation(instance)
         resp = defaultdict(dict)
@@ -31,26 +37,15 @@ class HalModelSerializer(HyperlinkedModelSerializer):
                     rel['title'] = ret.pop('_link_title')
                 resp[LINKS_FIELD_NAME][field_name] = rel
 
-
         for field_name in self.embedded_field_names:
             # if a related resource is embedded, it should still
             # get a link in the parent object
-            try:
-                if type([]) == type(ret[field_name]):
-                    resp[LINKS_FIELD_NAME][field_name] = []
-                    for item in ret[field_name]:
-                        embed_self = item.get(LINKS_FIELD_NAME, {}).get(URL_FIELD_NAME)
-                        if embed_self:
-                            resp[LINKS_FIELD_NAME][field_name].append(embed_self)
-                else:
-                    embed_self = ret[field_name].get(
-                        LINKS_FIELD_NAME,
-                        {}).get(URL_FIELD_NAME)
-                    if embed_self:
-                        resp[LINKS_FIELD_NAME][field_name] = embed_self
-            except AttributeError:
-                pass
-
+            if type(ret[field_name]) == list:
+                embed_self = [self._get_url(x) for x in ret[field_name] if x]
+            else:
+                embed_self = self._get_url(ret[field_name])
+            if embed_self:
+                resp[LINKS_FIELD_NAME][field_name] = embed_self
             resp[EMBEDDED_FIELD_NAME][field_name] = ret.pop(field_name)
 
         resp = dict(resp, **ret)

--- a/tests/testproject/models.py
+++ b/tests/testproject/models.py
@@ -7,7 +7,7 @@ class RelatedResource1(models.Model):
     active = models.BooleanField(default=True)
 
     @property
-    def title(self):
+    def _link_title(self):
         return 'some title'
 
 

--- a/tests/testproject/models.py
+++ b/tests/testproject/models.py
@@ -6,6 +6,10 @@ class RelatedResource1(models.Model):
     name = models.CharField(max_length=255)
     active = models.BooleanField(default=True)
 
+    @property
+    def title(self):
+        return 'some title'
+
 
 class RelatedResource2(models.Model):
     created = models.DateTimeField(auto_now=True)

--- a/tests/testproject/serializers.py
+++ b/tests/testproject/serializers.py
@@ -7,7 +7,7 @@ from .models import AbundantResource, CustomResource, TestResource, RelatedResou
 class RelatedResource1Serializer(HalModelSerializer):
     class Meta:
         model = RelatedResource1
-        fields = ('self', 'id', 'name', 'active')
+        fields = ('self', 'title', 'id', 'name', 'active')
 
 
 class RelatedResource2Serializer(HalModelSerializer):

--- a/tests/testproject/serializers.py
+++ b/tests/testproject/serializers.py
@@ -7,7 +7,7 @@ from .models import AbundantResource, CustomResource, TestResource, RelatedResou
 class RelatedResource1Serializer(HalModelSerializer):
     class Meta:
         model = RelatedResource1
-        fields = ('self', 'title', 'id', 'name', 'active')
+        fields = ('self', '_link_title', 'id', 'name', 'active')
 
 
 class RelatedResource2Serializer(HalModelSerializer):

--- a/tests/testproject/tests.py
+++ b/tests/testproject/tests.py
@@ -56,9 +56,16 @@ class HalTest(TestCase):
         test_resource_data = resp.data
         related_resource_2_data = test_resource_data[EMBEDDED_FIELD_NAME]['related_resource_2']
         related_resource_2_links = related_resource_2_data[LINKS_FIELD_NAME]
-        self.assertEqual(1, len(related_resource_2_links))
+        self.assertEqual(2, len(related_resource_2_links))
         self.assertEqual(self.TESTSERVER_URL + reverse('relatedresource2-detail', kwargs={'pk': self.related_resource_2.id}),
                          related_resource_2_links['self']['href'])
+
+    def test_link_titles(self):
+        resp = self.client.get("/related-resources-2/1/")
+        related = resp.data[LINKS_FIELD_NAME]['related_resources_1']
+        self.assertEqual(2, len(related))
+        self.assertEqual('some title', related[0]['title'])
+        self.assertEqual('some title', related[1]['title'])
 
     def test_deep_embedding(self):
         resp = self.client.get("/test-resources/1/")


### PR DESCRIPTION
This PR adds more conformity to the HAL spec with regards to links.

* Links can be arrays of link objects. Example by HAL spec author: https://groups.google.com/forum/#!msg/hal-discuss/1nntzRRAWQU/4a5AF6tB-loJ
* Support the optional `title` link attribute: https://tools.ietf.org/html/draft-kelly-json-hal-06#section-5.7

