### PR TITLE
Link titles through fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ Request:
             }
         }
     }
+    
+### Link titles
+
+The optional `title` attribute is supported for link relations. If a serializer includes a field called
+`title`, it will not be serialized as part of the object itself. Instead, the `title` field enhances
+the link relation of the object.
 
 See the [test project][] for a complete Django project with more examples. 
 

--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ Request:
     
 ### Link titles
 
-The optional `title` attribute is supported for link relations. If a serializer includes a field called
-`title`, it will not be serialized as part of the object itself. Instead, the `title` field enhances
-the link relation of the object.
+The [optional `title` attribute][hal spec title] is supported for link relations. If a serializer 
+includes a field called `_link_title`, it will not be serialized as part of the object itself. 
+Instead, the field labels the link relation of the object.
 
 See the [test project][] for a complete Django project with more examples. 
 
@@ -89,3 +89,4 @@ $> make test
 ```
 
 [test project]: tests/
+[hal spec title]: https://tools.ietf.org/html/draft-kelly-json-hal-06#section-5.7

--- a/README.md
+++ b/README.md
@@ -74,9 +74,10 @@ Request:
     
 ### Link titles
 
-The [optional `title` attribute][hal spec title] is supported for link relations. If a serializer 
-includes a field called `_link_title`, it will not be serialized as part of the object itself. 
-Instead, the field labels the link relation of the object.
+The [optional `title` attribute][hal spec title] is supported for link relations. For this,
+use the `HalHyperlinkedRelatedField` or `HalHyperlinkedIdentityField` field implementations.
+These support a `title_field` attribute which tells the serializer which model field to 
+use as the link title.
 
 See the [test project][] for a complete Django project with more examples. 
 

--- a/drf_hal_json/fields.py
+++ b/drf_hal_json/fields.py
@@ -16,3 +16,33 @@ class HyperlinkedPropertyField(serializers.Field):
 
     def to_internal_value(self, data):
         raise NotImplementedError()
+
+
+class HalHyperlinkedRelatedField(serializers.HyperlinkedRelatedField):
+
+    def __init__(self, **kwargs):
+        self.title_field = kwargs.pop('title_field', None)
+        super().__init__(**kwargs)
+
+    def to_representation(self, instance):
+        val = {'href': super().to_representation(instance)}
+
+        if self.title_field and getattr(instance, self.title_field):
+            val['title'] = getattr(instance, self.title_field)
+
+        return val
+
+
+class HalHyperlinkedIdentityField(serializers.HyperlinkedIdentityField):
+
+    def __init__(self, **kwargs):
+        self.title_field = kwargs.pop('title_field', None)
+        super().__init__(**kwargs)
+
+    def to_representation(self, instance):
+        val = {'href': super().to_representation(instance)}
+
+        if self.title_field and getattr(instance, self.title_field):
+            val['title'] = getattr(instance, self.title_field)
+
+        return val

--- a/drf_hal_json/serializers.py
+++ b/drf_hal_json/serializers.py
@@ -30,19 +30,31 @@ class HalModelSerializer(HyperlinkedModelSerializer):
         for field_name in self.link_field_names:
             val = ret.pop(field_name)
             if val is not None:
-                resp[LINKS_FIELD_NAME][field_name] = {'href': val}
+                rel = {'href': val}
+                if 'title' in ret:
+                    rel['title'] = ret.pop('title')
+                resp[LINKS_FIELD_NAME][field_name] = rel
+
 
         for field_name in self.embedded_field_names:
+            # if a related resource is embedded, it should still
+            # get a link in the parent object
             try:
-                # if a related resource is embedded, it should still
-                # get a link in the parent object
-                embed_self = ret[field_name].get(
-                    LINKS_FIELD_NAME,
-                    {}).get(URL_FIELD_NAME)
-                if embed_self:
-                    resp[LINKS_FIELD_NAME][field_name] = embed_self
+                if type([]) == type(ret[field_name]):
+                    resp[LINKS_FIELD_NAME][field_name] = []
+                    for item in ret[field_name]:
+                        embed_self = item.get(LINKS_FIELD_NAME, {}).get(URL_FIELD_NAME)
+                        if embed_self:
+                            resp[LINKS_FIELD_NAME][field_name].append(embed_self)
+                else:
+                    embed_self = ret[field_name].get(
+                        LINKS_FIELD_NAME,
+                        {}).get(URL_FIELD_NAME)
+                    if embed_self:
+                        resp[LINKS_FIELD_NAME][field_name] = embed_self
             except AttributeError:
                 pass
+
             resp[EMBEDDED_FIELD_NAME][field_name] = ret.pop(field_name)
 
         resp = dict(resp, **ret)

--- a/drf_hal_json/serializers.py
+++ b/drf_hal_json/serializers.py
@@ -31,8 +31,8 @@ class HalModelSerializer(HyperlinkedModelSerializer):
             val = ret.pop(field_name)
             if val is not None:
                 rel = {'href': val}
-                if 'title' in ret:
-                    rel['title'] = ret.pop('title')
+                if '_link_title' in ret:
+                    rel['title'] = ret.pop('_link_title')
                 resp[LINKS_FIELD_NAME][field_name] = rel
 
 

--- a/drf_hal_json/serializers.py
+++ b/drf_hal_json/serializers.py
@@ -3,11 +3,8 @@ from collections import defaultdict
 from drf_hal_json import EMBEDDED_FIELD_NAME, LINKS_FIELD_NAME, URL_FIELD_NAME
 from drf_hal_json.fields import HyperlinkedPropertyField
 from rest_framework.fields import empty
-from rest_framework.relations import (HyperlinkedIdentityField,
-                                      HyperlinkedRelatedField,
-                                      ManyRelatedField, RelatedField)
-from rest_framework.serializers import (BaseSerializer,
-                                        HyperlinkedModelSerializer)
+from rest_framework.relations import HyperlinkedIdentityField, HyperlinkedRelatedField, ManyRelatedField, RelatedField
+from rest_framework.serializers import BaseSerializer, HyperlinkedModelSerializer
 from rest_framework.utils.field_mapping import get_nested_relation_kwargs
 
 
@@ -30,6 +27,12 @@ class HalModelSerializer(HyperlinkedModelSerializer):
             return val
         return {'href': val}
 
+    def _get_url(self, item):
+        try:
+            return item.get(LINKS_FIELD_NAME, {}).get(URL_FIELD_NAME)
+        except AttributeError:
+            return None
+
     def to_representation(self, instance):
         ret = super().to_representation(instance)
         resp = defaultdict(dict)
@@ -42,22 +45,12 @@ class HalModelSerializer(HyperlinkedModelSerializer):
         for field_name in self.embedded_field_names:
             # if a related resource is embedded, it should still
             # get a link in the parent object
-            try:
-                if type([]) == type(ret[field_name]):
-                    resp[LINKS_FIELD_NAME][field_name] = []
-                    for item in ret[field_name]:
-                        embed_self = item.get(LINKS_FIELD_NAME, {}).get(URL_FIELD_NAME)
-                        if embed_self:
-                            resp[LINKS_FIELD_NAME][field_name].append(embed_self)
-                else:
-                    embed_self = ret[field_name].get(
-                        LINKS_FIELD_NAME,
-                        {}).get(URL_FIELD_NAME)
-                    if embed_self:
-                        resp[LINKS_FIELD_NAME][field_name] = embed_self
-            except AttributeError:
-                pass
-
+            if type(ret[field_name]) == list:
+                embed_self = [self._get_url(x) for x in ret[field_name] if x]
+            else:
+                embed_self = self._get_url(ret[field_name])
+            if embed_self:
+                resp[LINKS_FIELD_NAME][field_name] = embed_self
             resp[EMBEDDED_FIELD_NAME][field_name] = ret.pop(field_name)
 
         resp = dict(resp, **ret)

--- a/tests/testproject/models.py
+++ b/tests/testproject/models.py
@@ -7,7 +7,7 @@ class RelatedResource1(models.Model):
     active = models.BooleanField(default=True)
 
     @property
-    def title(self):
+    def _link_title(self):
         return 'some title'
 
 

--- a/tests/testproject/models.py
+++ b/tests/testproject/models.py
@@ -6,6 +6,10 @@ class RelatedResource1(models.Model):
     name = models.CharField(max_length=255)
     active = models.BooleanField(default=True)
 
+    @property
+    def title(self):
+        return 'some title'
+
 
 class RelatedResource2(models.Model):
     created = models.DateTimeField(auto_now=True)

--- a/tests/testproject/serializers.py
+++ b/tests/testproject/serializers.py
@@ -10,7 +10,7 @@ from .models import (AbundantResource, CustomResource, RelatedResource1,
 class RelatedResource1Serializer(HalModelSerializer):
     class Meta:
         model = RelatedResource1
-        fields = ('self', 'title', 'id', 'name', 'active')
+        fields = ('self', '_link_title', 'id', 'name', 'active')
 
 
 class RelatedResource2Serializer(HalModelSerializer):

--- a/tests/testproject/serializers.py
+++ b/tests/testproject/serializers.py
@@ -10,7 +10,7 @@ from .models import (AbundantResource, CustomResource, RelatedResource1,
 class RelatedResource1Serializer(HalModelSerializer):
     class Meta:
         model = RelatedResource1
-        fields = ('self', 'id', 'name', 'active')
+        fields = ('self', 'title', 'id', 'name', 'active')
 
 
 class RelatedResource2Serializer(HalModelSerializer):

--- a/tests/testproject/serializers.py
+++ b/tests/testproject/serializers.py
@@ -1,5 +1,6 @@
 from drf_hal_json.fields import HyperlinkedPropertyField
 from drf_hal_json.serializers import HalModelSerializer
+from drf_hal_json.fields import HalHyperlinkedRelatedField, HalHyperlinkedIdentityField
 from rest_framework import serializers
 
 from .models import (AbundantResource, CustomResource, RelatedResource1,
@@ -10,13 +11,13 @@ from .models import (AbundantResource, CustomResource, RelatedResource1,
 class RelatedResource1Serializer(HalModelSerializer):
     class Meta:
         model = RelatedResource1
-        fields = ('self', '_link_title', 'id', 'name', 'active')
+        fields = ('self', 'id', 'name', 'active')
 
 
 class RelatedResource2Serializer(HalModelSerializer):
-    # use nested serializer to control what fields are in the serialized, nested object
-    # (specifically we want 'id' to be included, which is not the default)
-    related_resources_1 = RelatedResource1Serializer(read_only=True, many=True)
+    # related_resources_1 are not embedded, just linked
+    related_resources_1 = HalHyperlinkedRelatedField(
+        many=True, read_only=True, view_name='relatedresource1-detail', title_field='name')
 
     class Meta:
         model = RelatedResource2
@@ -39,8 +40,9 @@ class RelatedResource3Serializer(HalModelSerializer):
 
 class CustomResourceSerializer(HalModelSerializer):
     related_resource_2 = RelatedResource2Serializer(read_only=True)
-    related_resource_3 = serializers.HyperlinkedIdentityField(
-        read_only=True, view_name='relatedresource3-detail', lookup_field='name')
+    related_resource_3 = HalHyperlinkedIdentityField(
+        read_only=True, view_name='relatedresource3-detail', lookup_field='name',
+        title_field='name')
 
     class Meta:
         model = CustomResource

--- a/tests/testproject/tests.py
+++ b/tests/testproject/tests.py
@@ -58,7 +58,7 @@ class HalTest(TestCase):
         resp = self.client.get("/test-resources/1/")
         test_resource_data = resp.data
         related_resource_2_data = test_resource_data[EMBEDDED_FIELD_NAME]['related_resource_2']
-        self.assertEqual(5, len(related_resource_2_data))
+        self.assertEqual(4, len(related_resource_2_data))
         self.assertEqual(self.related_resource_2.name, related_resource_2_data['name'])
 
     def test_embedded_resource_links(self):
@@ -75,32 +75,8 @@ class HalTest(TestCase):
         resp = self.client.get("/related-resources-2/1/")
         related = resp.data[LINKS_FIELD_NAME]['related_resources_1']
         self.assertEqual(2, len(related))
-        self.assertEqual('some title', related[0]['title'])
-        self.assertEqual('some title', related[1]['title'])
-
-    def test_deep_embedding(self):
-        resp = self.client.get("/test-resources/1/")
-        test_resource_data = resp.data
-        related_resource_2_data = test_resource_data[EMBEDDED_FIELD_NAME]['related_resource_2']
-        related_resource_2_links = related_resource_2_data[LINKS_FIELD_NAME]
-        related_resource_2_embedded = related_resource_2_data[EMBEDDED_FIELD_NAME]
-        self.assertEqual(1, len(related_resource_2_embedded))
-        nested_related_resources_data = related_resource_2_embedded['related_resources_1']
-        self.assertEqual(2, len(nested_related_resources_data))
-        self.assertEqual(4, len(nested_related_resources_data[0]))
-        self.assertEqual(4, len(nested_related_resources_data[1]))
-        self.assertEqual(self.nested_related_resource_1_1.id, nested_related_resources_data[0]['id'])
-        self.assertEqual(self.nested_related_resource_1_1.name, nested_related_resources_data[0]['name'])
-        self.assertEqual(
-            self.TESTSERVER_URL +
-            reverse('relatedresource1-detail', kwargs={'pk': self.nested_related_resource_1_1.id}),
-            nested_related_resources_data[0][LINKS_FIELD_NAME]['self']['href'])
-        self.assertEqual(self.nested_related_resource_1_2.id, nested_related_resources_data[1]['id'])
-        self.assertEqual(self.nested_related_resource_1_2.name, nested_related_resources_data[1]['name'])
-        self.assertEqual(
-            self.TESTSERVER_URL +
-            reverse('relatedresource1-detail', kwargs={'pk': self.nested_related_resource_1_2.id}),
-            nested_related_resources_data[1][LINKS_FIELD_NAME]['self']['href'])
+        # self.assertEqual('some title', related[0]['title'])
+        # self.assertEqual('some title', related[1]['title'])
 
     def test_custom_lookup_field(self):
         resp = self.client.get("/custom-resources/1/")
@@ -112,6 +88,8 @@ class HalTest(TestCase):
         self.assertEqual(
             self.TESTSERVER_URL + reverse("relatedresource3-detail", kwargs={"name": self.custom_resource_1.name}),
             custom_resource_links["related_resource_3"]["href"])
+        self.assertEqual(self.custom_resource_1.name,
+                         custom_resource_links["related_resource_3"]["title"])
 
     def test_hyperlinked_property_field(self):
         resp = self.client.get("/url-resources/1/")

--- a/tests/testproject/tests.py
+++ b/tests/testproject/tests.py
@@ -66,10 +66,17 @@ class HalTest(TestCase):
         test_resource_data = resp.data
         related_resource_2_data = test_resource_data[EMBEDDED_FIELD_NAME]['related_resource_2']
         related_resource_2_links = related_resource_2_data[LINKS_FIELD_NAME]
-        self.assertEqual(1, len(related_resource_2_links))
+        self.assertEqual(2, len(related_resource_2_links))
         self.assertEqual(
             self.TESTSERVER_URL + reverse('relatedresource2-detail', kwargs={'pk': self.related_resource_2.id}),
             related_resource_2_links['self']['href'])
+
+    def test_link_titles(self):
+        resp = self.client.get("/related-resources-2/1/")
+        related = resp.data[LINKS_FIELD_NAME]['related_resources_1']
+        self.assertEqual(2, len(related))
+        self.assertEqual('some title', related[0]['title'])
+        self.assertEqual('some title', related[1]['title'])
 
     def test_deep_embedding(self):
         resp = self.client.get("/test-resources/1/")

--- a/tests/testproject/tests.py
+++ b/tests/testproject/tests.py
@@ -75,8 +75,8 @@ class HalTest(TestCase):
         resp = self.client.get("/related-resources-2/1/")
         related = resp.data[LINKS_FIELD_NAME]['related_resources_1']
         self.assertEqual(2, len(related))
-        # self.assertEqual('some title', related[0]['title'])
-        # self.assertEqual('some title', related[1]['title'])
+        self.assertEqual('Nested-Related-Resource11', related[0]['title'])
+        self.assertEqual('Nested-Related-Resource12', related[1]['title'])
 
     def test_custom_lookup_field(self):
         resp = self.client.get("/custom-resources/1/")


### PR DESCRIPTION
This is an alternative approach to https://github.com/Artory/drf-hal-json/pull/8.

Links are created using custom fields which support a `title_field` attribute, which tells the serializer which model field to use for putting a title on the relation.

### TODO

- [ ] Support titles for the `self` link as well. This would make titles show up for the implicit links that are rendered when a related object is embedded (https://github.com/Artory/drf-hal-json/blob/link-titles-through-fields/drf_hal_json/serializers.py#L38-L55), since that code copies the `self` link from the embedded objects.