### PR TITLE
Support FileField and ImageField serialization to links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,7 @@ docs/_build/
 target/
 
 **/.idea/*
+.vscode
+tests/foo*
+tests/image*
+*.orig

--- a/drf_hal_json/fields.py
+++ b/drf_hal_json/fields.py
@@ -2,7 +2,7 @@ from rest_framework import serializers
 from rest_framework.relations import Hyperlink
 
 
-class HyperlinkedPropertyField(serializers.Field):
+class HalHyperlinkedPropertyField(serializers.Field):
     process_value = None
 
     def __init__(self, **kwargs):
@@ -16,3 +16,74 @@ class HyperlinkedPropertyField(serializers.Field):
 
     def to_internal_value(self, data):
         raise NotImplementedError()
+
+
+class HalContributeToLinkField(serializers.SerializerMethodField):
+    # https://tools.ietf.org/html/draft-kelly-json-hal-08#section-5
+
+    def __init__(self, **kwargs):
+        self.property_name = kwargs.pop('property_name', 'title')
+        self.place_on = kwargs.pop('place_on')
+        super().__init__(**kwargs)
+
+
+class HalHyperlinkedRelatedField(serializers.HyperlinkedRelatedField):
+
+    def __init__(self, **kwargs):
+        self.title_field = kwargs.pop('title_field', None)
+        self.templated_field = kwargs.pop('templated_field', None)
+        self.type_field = kwargs.pop('type_field', None)
+        self.deprecation_field = kwargs.pop('deprecation_field', None)
+        self.name_field = kwargs.pop('name_field', None)
+        super().__init__(**kwargs)
+
+    def to_representation(self, instance):
+        val = {'href': super().to_representation(instance)}
+
+        if self.title_field and getattr(instance, self.title_field):
+            val['title'] = getattr(instance, self.title_field)
+
+        if self.templated_field and getattr(instance, self.templated_field):
+            val['templated'] = getattr(instance, self.templated_field)
+
+        if self.type_field and getattr(instance, self.type_field):
+            val['type'] = getattr(instance, self.type_field)
+
+        if self.deprecation_field and getattr(instance, self.deprecation_field):
+            val['deprecation'] = getattr(instance, self.deprecation_field)
+
+        if self.name_field and getattr(instance, self.name_field):
+            val['name'] = getattr(instance, self.name_field)
+
+        return val
+
+
+class HalHyperlinkedIdentityField(serializers.HyperlinkedIdentityField):
+
+    def __init__(self, **kwargs):
+        self.title_field = kwargs.pop('title_field', None)
+        self.templated_field = kwargs.pop('templated_field', None)
+        self.type_field = kwargs.pop('type_field', None)
+        self.deprecation_field = kwargs.pop('deprecation_field', None)
+        self.name_field = kwargs.pop('name_field', None)
+        super().__init__(**kwargs)
+
+    def to_representation(self, instance):
+        val = {'href': super().to_representation(instance)}
+
+        if self.title_field and getattr(instance, self.title_field):
+            val['title'] = getattr(instance, self.title_field)
+
+        if self.templated_field and getattr(instance, self.templated_field):
+            val['templated'] = getattr(instance, self.templated_field)
+
+        if self.type_field and getattr(instance, self.type_field):
+            val['type'] = getattr(instance, self.type_field)
+
+        if self.deprecation_field and getattr(instance, self.deprecation_field):
+            val['deprecation'] = getattr(instance, self.deprecation_field)
+
+        if self.name_field and getattr(instance, self.name_field):
+            val['name'] = getattr(instance, self.name_field)
+
+        return val

--- a/drf_hal_json/serializers.py
+++ b/drf_hal_json/serializers.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 
 from drf_hal_json import EMBEDDED_FIELD_NAME, LINKS_FIELD_NAME, URL_FIELD_NAME
 from drf_hal_json.fields import HyperlinkedPropertyField
-from rest_framework.fields import empty
+from rest_framework.fields import empty, FileField, ImageField
 from rest_framework.relations import (HyperlinkedIdentityField,
                                       HyperlinkedRelatedField,
                                       ManyRelatedField, RelatedField)
@@ -66,7 +66,9 @@ class HalModelSerializer(HyperlinkedModelSerializer):
         return (isinstance(field, RelatedField) or
                 isinstance(field, ManyRelatedField) or
                 isinstance(field, HyperlinkedIdentityField) or
-                isinstance(field, HyperlinkedPropertyField))
+                isinstance(field, HyperlinkedPropertyField) or
+                isinstance(field, FileField) or
+                isinstance(field, ImageField))
 
     @staticmethod
     def _is_embedded_field(field):

--- a/drf_hal_json/serializers.py
+++ b/drf_hal_json/serializers.py
@@ -1,13 +1,10 @@
 from collections import defaultdict
 
 from drf_hal_json import EMBEDDED_FIELD_NAME, LINKS_FIELD_NAME, URL_FIELD_NAME
-from drf_hal_json.fields import HyperlinkedPropertyField
+from drf_hal_json.fields import HalHyperlinkedPropertyField, HalContributeToLinkField
 from rest_framework.fields import empty, FileField, ImageField
-from rest_framework.relations import (HyperlinkedIdentityField,
-                                      HyperlinkedRelatedField,
-                                      ManyRelatedField, RelatedField)
-from rest_framework.serializers import (BaseSerializer,
-                                        HyperlinkedModelSerializer)
+from rest_framework.relations import HyperlinkedIdentityField, HyperlinkedRelatedField, ManyRelatedField, RelatedField
+from rest_framework.serializers import BaseSerializer, HyperlinkedModelSerializer
 from rest_framework.utils.field_mapping import get_nested_relation_kwargs
 
 
@@ -23,6 +20,19 @@ class HalModelSerializer(HyperlinkedModelSerializer):
         if data != empty and not LINKS_FIELD_NAME in data:
             data[LINKS_FIELD_NAME] = dict()  # put links in data, so that field validation does not fail
 
+    def build_link_object(self, val):
+        if (type([]) == type(val)):
+            return [self.build_link_object(v) for v in val]
+        if isinstance(val, dict) and val.get('href', False):
+            return val
+        return {'href': val}
+
+    def _get_url(self, item):
+        try:
+            return item.get(LINKS_FIELD_NAME, {}).get(URL_FIELD_NAME)
+        except AttributeError:
+            return None
+
     def to_representation(self, instance):
         ret = super().to_representation(instance)
         resp = defaultdict(dict)
@@ -30,19 +40,20 @@ class HalModelSerializer(HyperlinkedModelSerializer):
         for field_name in self.link_field_names:
             val = ret.pop(field_name)
             if val is not None:
-                resp[LINKS_FIELD_NAME][field_name] = {'href': val}
+                resp[LINKS_FIELD_NAME][field_name] = self.build_link_object(val)
+                for property_name in self.link_property_fields.get(field_name, []):
+                    prop = ret.pop(self.link_property_fields[field_name][property_name])
+                    resp[LINKS_FIELD_NAME][field_name][property_name] = prop
 
         for field_name in self.embedded_field_names:
-            try:
-                # if a related resource is embedded, it should still
-                # get a link in the parent object
-                embed_self = ret[field_name].get(
-                    LINKS_FIELD_NAME,
-                    {}).get(URL_FIELD_NAME)
-                if embed_self:
-                    resp[LINKS_FIELD_NAME][field_name] = embed_self
-            except AttributeError:
-                pass
+            # if a related resource is embedded, it should still
+            # get a link in the parent object
+            if type(ret[field_name]) == list:
+                embed_self = [self._get_url(x) for x in ret[field_name] if x]
+            else:
+                embed_self = self._get_url(ret[field_name])
+            if embed_self:
+                resp[LINKS_FIELD_NAME][field_name] = embed_self
             resp[EMBEDDED_FIELD_NAME][field_name] = ret.pop(field_name)
 
         resp = dict(resp, **ret)
@@ -53,10 +64,13 @@ class HalModelSerializer(HyperlinkedModelSerializer):
 
         self.embedded_field_names = []
         self.link_field_names = []
+        self.link_property_fields = defaultdict(dict)
 
         for field_name, field in fields.items():
             if self._is_link_field(field):
                 self.link_field_names.append(field_name)
+            if self._is_link_contribution_field(field):
+                self.link_property_fields[field.place_on][field.property_name] = field_name
             elif self._is_embedded_field(field):
                 self.embedded_field_names.append(field_name)
         return fields
@@ -66,9 +80,13 @@ class HalModelSerializer(HyperlinkedModelSerializer):
         return (isinstance(field, RelatedField) or
                 isinstance(field, ManyRelatedField) or
                 isinstance(field, HyperlinkedIdentityField) or
-                isinstance(field, HyperlinkedPropertyField) or
+                isinstance(field, HalHyperlinkedPropertyField) or
                 isinstance(field, FileField) or
                 isinstance(field, ImageField))
+
+    @staticmethod
+    def _is_link_contribution_field(field):
+        return isinstance(field, HalContributeToLinkField)
 
     @staticmethod
     def _is_embedded_field(field):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Django==1.11.2
 djangorestframework==3.6.3
+Pillow==4.1.1

--- a/tests/testproject/migrations/0001_initial.py
+++ b/tests/testproject/migrations/0001_initial.py
@@ -75,6 +75,14 @@ class Migration(migrations.Migration):
                 ('url', models.CharField(max_length=255)),
             ],
         ),
+        migrations.CreateModel(
+            name='FileResource',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('file', models.FileField(max_length=255)),
+                ('image', models.ImageField(max_length=255)),
+            ],
+        ),
         migrations.AddField(
             model_name='customresource',
             name='related_resource_2',

--- a/tests/testproject/models.py
+++ b/tests/testproject/models.py
@@ -41,3 +41,8 @@ class AbundantResource(models.Model):
 
 class URLResource(models.Model):
     url = models.CharField(max_length=255)
+
+
+class FileResource(models.Model):
+    file = models.FileField(max_length=255)
+    image = models.ImageField(max_length=255)

--- a/tests/testproject/models.py
+++ b/tests/testproject/models.py
@@ -6,6 +6,10 @@ class RelatedResource1(models.Model):
     name = models.CharField(max_length=255)
     active = models.BooleanField(default=True)
 
+    @property
+    def _link_title(self):
+        return 'some title'
+
 
 class RelatedResource2(models.Model):
     created = models.DateTimeField(auto_now=True)

--- a/tests/testproject/serializers.py
+++ b/tests/testproject/serializers.py
@@ -4,7 +4,7 @@ from rest_framework import serializers
 
 from .models import (AbundantResource, CustomResource, RelatedResource1,
                      RelatedResource2, RelatedResource3, TestResource,
-                     URLResource)
+                     URLResource, FileResource)
 
 
 class RelatedResource1Serializer(HalModelSerializer):
@@ -62,3 +62,10 @@ class HyperlinkedPropertySerializer(HalModelSerializer):
     class Meta:
         model = URLResource
         fields = ('self', 'url', 'url_processed')
+
+
+class FileSerializer(HalModelSerializer):
+
+    class Meta:
+        model = FileResource
+        fields = ('self', 'file', 'image')

--- a/tests/testproject/serializers.py
+++ b/tests/testproject/serializers.py
@@ -1,5 +1,6 @@
-from drf_hal_json.fields import HyperlinkedPropertyField
+from drf_hal_json.fields import HalHyperlinkedPropertyField, HalContributeToLinkField
 from drf_hal_json.serializers import HalModelSerializer
+from drf_hal_json.fields import HalHyperlinkedRelatedField, HalHyperlinkedIdentityField
 from rest_framework import serializers
 
 from .models import (AbundantResource, CustomResource, RelatedResource1,
@@ -8,19 +9,28 @@ from .models import (AbundantResource, CustomResource, RelatedResource1,
 
 
 class RelatedResource1Serializer(HalModelSerializer):
+    name = HalContributeToLinkField(place_on='self', property_name='title')
+
     class Meta:
         model = RelatedResource1
         fields = ('self', 'id', 'name', 'active')
 
+    def get_name(self, obj):
+        return obj.name
+
 
 class RelatedResource2Serializer(HalModelSerializer):
-    # use nested serializer to control what fields are in the serialized, nested object
-    # (specifically we want 'id' to be included, which is not the default)
-    related_resources_1 = RelatedResource1Serializer(read_only=True, many=True)
+    # These related resources are not embedded, just linked
+    related_resources = serializers.HyperlinkedRelatedField(
+        many=True, read_only=True, view_name='relatedresource1-detail',
+        source='related_resources_1')
+    related_resources_1 = HalHyperlinkedRelatedField(
+        many=True, read_only=True, view_name='relatedresource1-detail',
+        title_field='name')
 
     class Meta:
         model = RelatedResource2
-        fields = ('self', 'id', 'name', 'active', 'related_resources_1')
+        fields = ('self', 'id', 'name', 'active', 'related_resources', 'related_resources_1')
 
 
 class TestResourceSerializer(HalModelSerializer):
@@ -33,18 +43,23 @@ class TestResourceSerializer(HalModelSerializer):
 
 
 class RelatedResource3Serializer(HalModelSerializer):
+
     class Meta:
         model = RelatedResource3
 
 
 class CustomResourceSerializer(HalModelSerializer):
     related_resource_2 = RelatedResource2Serializer(read_only=True)
-    related_resource_3 = serializers.HyperlinkedIdentityField(
+    related_resource_3 = HalHyperlinkedIdentityField(
         read_only=True, view_name='relatedresource3-detail', lookup_field='name')
+    name = HalContributeToLinkField(place_on='related_resource_3', property_name='title')
 
     class Meta:
         model = CustomResource
         fields = ('self', 'name', 'related_resource_2', 'related_resource_3')
+
+    def get_name(self, obj):
+        return obj.name
 
 
 class AbundantResourceSerializer(HalModelSerializer):
@@ -54,8 +69,8 @@ class AbundantResourceSerializer(HalModelSerializer):
 
 
 class HyperlinkedPropertySerializer(HalModelSerializer):
-    url = HyperlinkedPropertyField()
-    url_processed = HyperlinkedPropertyField(
+    url = HalHyperlinkedPropertyField()
+    url_processed = HalHyperlinkedPropertyField(
         source='url',
         process_value=lambda val: val + '?foo=bar')
 
@@ -65,7 +80,19 @@ class HyperlinkedPropertySerializer(HalModelSerializer):
 
 
 class FileSerializer(HalModelSerializer):
+    self_title = HalContributeToLinkField(place_on='self')
+    file_title = HalContributeToLinkField(place_on='file')
+    file_type = HalContributeToLinkField(place_on='file', property_name='type')
 
     class Meta:
         model = FileResource
-        fields = ('self', 'file', 'image')
+        fields = ('self', 'self_title', 'file', 'file_title', 'file_type', 'image')
+
+    def get_self_title(self, obj):
+        return str(obj.pk)
+
+    def get_file_title(self, obj):
+        return obj.file.name
+
+    def get_file_type(self, obj):
+        return 'application/zip'

--- a/tests/testproject/tests.py
+++ b/tests/testproject/tests.py
@@ -1,9 +1,10 @@
+from django.core.files.base import ContentFile
 from django.test import TestCase
 from drf_hal_json import EMBEDDED_FIELD_NAME, LINKS_FIELD_NAME
 from rest_framework.reverse import reverse
 
 from .models import (AbundantResource, CustomResource, RelatedResource1, RelatedResource2, RelatedResource3,
-                     TestResource, URLResource)
+                     TestResource, URLResource, FileResource)
 
 
 class HalTest(TestCase):
@@ -28,6 +29,9 @@ class HalTest(TestCase):
             related_resource_3=self.related_resource_3,
             related_resource_2=self.related_resource_2)
         self.url_resource = URLResource.objects.create(url="https://www.example.com/")
+        self.file_resource = FileResource()
+        self.file_resource.file.save('foo', ContentFile(b'bar'))
+        self.file_resource.image.save('image', ContentFile(b'JPEG'))
 
         for i in range(0, 50):
             AbundantResource.objects.create(name="Abundant Resource {}".format(i))
@@ -139,3 +143,9 @@ class HalTest(TestCase):
         resp = self.client.get("/custom-resources/2/")
         custom_resource_links = resp.data[LINKS_FIELD_NAME]
         self.assertIn("related_resource_2", custom_resource_links)
+
+    def test_filefield_serialization(self):
+        resp = self.client.get("/file-resources/1/")
+        custom_resource_links = resp.data[LINKS_FIELD_NAME]
+        self.assertIn("file", custom_resource_links)
+        self.assertIn("image", custom_resource_links)

--- a/tests/testproject/tests.py
+++ b/tests/testproject/tests.py
@@ -62,7 +62,7 @@ class HalTest(TestCase):
         resp = self.client.get("/test-resources/1/")
         test_resource_data = resp.data
         related_resource_2_data = test_resource_data[EMBEDDED_FIELD_NAME]['related_resource_2']
-        self.assertEqual(5, len(related_resource_2_data))
+        self.assertEqual(4, len(related_resource_2_data))
         self.assertEqual(self.related_resource_2.name, related_resource_2_data['name'])
 
     def test_embedded_resource_links(self):
@@ -70,34 +70,17 @@ class HalTest(TestCase):
         test_resource_data = resp.data
         related_resource_2_data = test_resource_data[EMBEDDED_FIELD_NAME]['related_resource_2']
         related_resource_2_links = related_resource_2_data[LINKS_FIELD_NAME]
-        self.assertEqual(1, len(related_resource_2_links))
+        self.assertEqual(3, len(related_resource_2_links))
         self.assertEqual(
             self.TESTSERVER_URL + reverse('relatedresource2-detail', kwargs={'pk': self.related_resource_2.id}),
             related_resource_2_links['self']['href'])
 
-    def test_deep_embedding(self):
-        resp = self.client.get("/test-resources/1/")
-        test_resource_data = resp.data
-        related_resource_2_data = test_resource_data[EMBEDDED_FIELD_NAME]['related_resource_2']
-        related_resource_2_links = related_resource_2_data[LINKS_FIELD_NAME]
-        related_resource_2_embedded = related_resource_2_data[EMBEDDED_FIELD_NAME]
-        self.assertEqual(1, len(related_resource_2_embedded))
-        nested_related_resources_data = related_resource_2_embedded['related_resources_1']
-        self.assertEqual(2, len(nested_related_resources_data))
-        self.assertEqual(4, len(nested_related_resources_data[0]))
-        self.assertEqual(4, len(nested_related_resources_data[1]))
-        self.assertEqual(self.nested_related_resource_1_1.id, nested_related_resources_data[0]['id'])
-        self.assertEqual(self.nested_related_resource_1_1.name, nested_related_resources_data[0]['name'])
-        self.assertEqual(
-            self.TESTSERVER_URL +
-            reverse('relatedresource1-detail', kwargs={'pk': self.nested_related_resource_1_1.id}),
-            nested_related_resources_data[0][LINKS_FIELD_NAME]['self']['href'])
-        self.assertEqual(self.nested_related_resource_1_2.id, nested_related_resources_data[1]['id'])
-        self.assertEqual(self.nested_related_resource_1_2.name, nested_related_resources_data[1]['name'])
-        self.assertEqual(
-            self.TESTSERVER_URL +
-            reverse('relatedresource1-detail', kwargs={'pk': self.nested_related_resource_1_2.id}),
-            nested_related_resources_data[1][LINKS_FIELD_NAME]['self']['href'])
+    def test_link_titles(self):
+        resp = self.client.get("/related-resources-2/1/")
+        related = resp.data[LINKS_FIELD_NAME]['related_resources_1']
+        self.assertEqual(2, len(related))
+        self.assertEqual('Nested-Related-Resource11', related[0]['title'])
+        self.assertEqual('Nested-Related-Resource12', related[1]['title'])
 
     def test_custom_lookup_field(self):
         resp = self.client.get("/custom-resources/1/")
@@ -109,6 +92,8 @@ class HalTest(TestCase):
         self.assertEqual(
             self.TESTSERVER_URL + reverse("relatedresource3-detail", kwargs={"name": self.custom_resource_1.name}),
             custom_resource_links["related_resource_3"]["href"])
+        self.assertEqual(self.custom_resource_1.name,
+                         custom_resource_links["related_resource_3"]["title"])
 
     def test_hyperlinked_property_field(self):
         resp = self.client.get("/url-resources/1/")
@@ -148,4 +133,6 @@ class HalTest(TestCase):
         resp = self.client.get("/file-resources/1/")
         custom_resource_links = resp.data[LINKS_FIELD_NAME]
         self.assertIn("file", custom_resource_links)
+        self.assertIn("title", custom_resource_links['file'])
+        self.assertEqual(custom_resource_links['file']['type'], "application/zip")
         self.assertIn("image", custom_resource_links)

--- a/tests/testproject/urls.py
+++ b/tests/testproject/urls.py
@@ -4,7 +4,7 @@ from rest_framework.routers import DefaultRouter
 from .views import (AbundantResourceViewSet, CustomResourceViewSet,
                     RelatedResource1ViewSet, RelatedResource2ViewSet,
                     RelatedResource3ViewSet, TestResourceViewSet,
-                    URLResourceViewSet)
+                    URLResourceViewSet, FileResourceViewSet)
 
 router = DefaultRouter()
 router.register(r'test-resources', TestResourceViewSet)
@@ -14,4 +14,5 @@ router.register(r'related-resources-3', RelatedResource3ViewSet)
 router.register(r'custom-resources', CustomResourceViewSet)
 router.register(r'abundant-resources', AbundantResourceViewSet)
 router.register(r'url-resources', URLResourceViewSet)
+router.register(r'file-resources', FileResourceViewSet)
 urlpatterns = router.urls

--- a/tests/testproject/views.py
+++ b/tests/testproject/views.py
@@ -3,12 +3,13 @@ from rest_framework.viewsets import ModelViewSet
 
 from .models import (AbundantResource, CustomResource, RelatedResource1,
                      RelatedResource2, RelatedResource3, TestResource,
-                     URLResource)
+                     URLResource, FileResource)
 from .serializers import (AbundantResourceSerializer, CustomResourceSerializer,
                           HyperlinkedPropertySerializer,
                           RelatedResource1Serializer,
                           RelatedResource2Serializer,
-                          RelatedResource3Serializer, TestResourceSerializer)
+                          RelatedResource3Serializer, TestResourceSerializer,
+                          FileSerializer)
 
 
 class CustomResourceViewSet(HalCreateModelMixin, ModelViewSet):
@@ -45,3 +46,8 @@ class AbundantResourceViewSet(HalCreateModelMixin, ModelViewSet):
 class URLResourceViewSet(HalCreateModelMixin, ModelViewSet):
     serializer_class = HyperlinkedPropertySerializer
     queryset = URLResource.objects.all()
+
+
+class FileResourceViewSet(HalCreateModelMixin, ModelViewSet):
+    serializer_class = FileSerializer
+    queryset = FileResource.objects.all()


### PR DESCRIPTION
This renders file and image fields into links as well:

```json
{
    "_links": {
        "self": {
            "href": "http://testserver/file-resources/1/"
        },
        "file": {
            "href": "http://testserver/file-resources/1/foo_ZQBLrGA"
        },
        "image": {
            "href": "http://testserver/file-resources/1/image_FOyklJw"
        }
    }
}
```