### PR TITLE
Filter out None before making list from embedded to put in links

### DIFF
--- a/drf_hal_json/serializers.py
+++ b/drf_hal_json/serializers.py
@@ -50,7 +50,7 @@ class HalModelSerializer(HyperlinkedModelSerializer):
             # if a related resource is embedded, it should still
             # get a link in the parent object
             if type(ret[field_name]) == list:
-                embed_self = [self._get_url(x) for x in ret[field_name] if x]
+                embed_self = list(filter(None.__ne__, [self._get_url(x) for x in ret[field_name] if x]))
             else:
                 embed_self = self._get_url(ret[field_name])
             if embed_self:

--- a/tests/testproject/serializers.py
+++ b/tests/testproject/serializers.py
@@ -19,6 +19,12 @@ class RelatedResource1Serializer(HalModelSerializer):
         return obj.name
 
 
+class RelatedResource1NoSelfSerializer(RelatedResource1Serializer):
+    class Meta:
+        model = RelatedResource1
+        fields = ('id', 'name', 'active')
+
+
 class RelatedResource2Serializer(HalModelSerializer):
     # These related resources are not embedded, just linked
     related_resources = serializers.HyperlinkedRelatedField(
@@ -27,10 +33,11 @@ class RelatedResource2Serializer(HalModelSerializer):
     related_resources_1 = HalHyperlinkedRelatedField(
         many=True, read_only=True, view_name='relatedresource1-detail',
         title_field='name')
+    related_resources_1_noself = RelatedResource1NoSelfSerializer(many=True, source='related_resources_1')
 
     class Meta:
         model = RelatedResource2
-        fields = ('self', 'id', 'name', 'active', 'related_resources', 'related_resources_1')
+        fields = ('self', 'id', 'name', 'active', 'related_resources', 'related_resources_1', 'related_resources_1_noself')
 
 
 class TestResourceSerializer(HalModelSerializer):

--- a/tests/testproject/serializers.py
+++ b/tests/testproject/serializers.py
@@ -37,7 +37,8 @@ class RelatedResource2Serializer(HalModelSerializer):
 
     class Meta:
         model = RelatedResource2
-        fields = ('self', 'id', 'name', 'active', 'related_resources', 'related_resources_1', 'related_resources_1_noself')
+        fields = ('self', 'id', 'name', 'active', 'related_resources', 'related_resources_1',
+                  'related_resources_1_noself')
 
 
 class TestResourceSerializer(HalModelSerializer):

--- a/tests/testproject/tests.py
+++ b/tests/testproject/tests.py
@@ -62,7 +62,7 @@ class HalTest(TestCase):
         resp = self.client.get("/test-resources/1/")
         test_resource_data = resp.data
         related_resource_2_data = test_resource_data[EMBEDDED_FIELD_NAME]['related_resource_2']
-        self.assertEqual(4, len(related_resource_2_data))
+        self.assertEqual(5, len(related_resource_2_data))
         self.assertEqual(self.related_resource_2.name, related_resource_2_data['name'])
 
     def test_embedded_resource_links(self):


### PR DESCRIPTION
Fixes problem of array with null values appearing for serializers that don't define 'self'.