### PR TITLE
HAL List Serializer

### DIFF
--- a/drf_hal_json/serializers.py
+++ b/drf_hal_json/serializers.py
@@ -59,7 +59,7 @@ class HalModelSerializer(HyperlinkedModelSerializer):
 
     @classmethod
     def many_init(cls, *args, **kwargs):
-        # duplicate ListSerializer.many_init due to Meta dependency (injecting a value was not possible)
+        # duplicate BaseSerializer.many_init due to Meta dependency (injecting a value was not possible)
         allow_empty = kwargs.pop('allow_empty', None)
         child_serializer = cls(*args, **kwargs)
         list_kwargs = {
@@ -73,7 +73,7 @@ class HalModelSerializer(HyperlinkedModelSerializer):
         })
         meta = getattr(cls, 'Meta', None)
         list_serializer_class = getattr(meta, 'list_serializer_class', HalListSerializer)
-        return list_serializer_class(*args, **kwargs)
+        return list_serializer_class(*args, **list_kwargs)
 
     def build_link_object(self, val):
         if (type([]) == type(val)):

--- a/drf_hal_json/serializers.py
+++ b/drf_hal_json/serializers.py
@@ -17,23 +17,17 @@ class HalListSerializer(ListSerializer):
     @property
     def data(self):
         # The parent class returns ReturnList
-        ret = super(ListSerializer, self).data
-        return ReturnDict(ret, serializer=self)
-
-    def to_representation(self, collection):
-        # cribbed from HyperlinkedRelatedField.to_representation
-        assert 'request' in self.context, (
-            "`%s` requires the request in the serializer"
-            " context. Add `context={'request': request}` when instantiating "
-            "the serializer." % self.__class__.__name__
-        )
-        # Wrap the standard ListSerializer in _embedded and populate _links with the URL of the list
-        return {
-            LINKS_FIELD_NAME: {
-                URL_FIELD_NAME: {'href': self.build_view_url()},
+        return ReturnDict(
+            {
+                LINKS_FIELD_NAME: {
+                    URL_FIELD_NAME: {
+                        'href': self.build_view_url()
+                    }
+                },
+                EMBEDDED_FIELD_NAME: super(ListSerializer, self).data
             },
-            EMBEDDED_FIELD_NAME: super(HalListSerializer, self).to_representation(collection)
-        }
+            serializer=self
+        )
 
     def build_view_url(self):
         # Deduce the URL of the view from the Model
@@ -165,7 +159,3 @@ class HalModelSerializer(HyperlinkedModelSerializer):
         field_kwargs = get_nested_relation_kwargs(relation_info)
 
         return field_class, field_kwargs
-
-
-class HalRelatedModelSerializer(HalModelSerializer):
-    default_list_serializer = ListSerializer

--- a/drf_hal_json/serializers.py
+++ b/drf_hal_json/serializers.py
@@ -1,6 +1,5 @@
 from collections import defaultdict
 
-import rest_framework
 from rest_framework.reverse import reverse
 from rest_framework.utils.serializer_helpers import ReturnDict
 

--- a/drf_hal_json/serializers.py
+++ b/drf_hal_json/serializers.py
@@ -24,7 +24,10 @@ class HalListSerializer(ListSerializer):
                         'href': self.build_view_url()
                     }
                 },
-                EMBEDDED_FIELD_NAME: super(ListSerializer, self).data
+                EMBEDDED_FIELD_NAME: {
+                    # `items` mirrors hardcoded value in pagination classes
+                    'items': super(ListSerializer, self).data
+                }
             },
             serializer=self
         )

--- a/drf_hal_json/serializers.py
+++ b/drf_hal_json/serializers.py
@@ -1,6 +1,5 @@
 from collections import defaultdict
 
-from rest_framework.reverse import reverse
 from rest_framework.utils.serializer_helpers import ReturnDict
 
 from drf_hal_json import EMBEDDED_FIELD_NAME, LINKS_FIELD_NAME, URL_FIELD_NAME
@@ -21,7 +20,7 @@ class HalListSerializer(ListSerializer):
             {
                 LINKS_FIELD_NAME: {
                     URL_FIELD_NAME: {
-                        'href': self.build_view_url()
+                        'href': self.context['request'].build_absolute_uri()
                     }
                 },
                 EMBEDDED_FIELD_NAME: {
@@ -31,20 +30,6 @@ class HalListSerializer(ListSerializer):
             },
             serializer=self
         )
-
-    def build_view_url(self):
-        # Deduce the URL of the view from the Model
-        model = getattr(self.child.Meta, 'model')
-        # Support a Meta attribute for adjusting the base_name
-        base_name = getattr(self.child.Meta, 'base_name', None)
-        if base_name is None:
-            # basic approach from rest_framework.utils.field_mapping.get_detail_view_name
-            base_name = '%(model_name)s' % {
-                'app_label': model._meta.app_label,
-                'model_name': model._meta.object_name.lower()
-            }
-        view_name = '{}-list'.format(base_name)
-        return reverse(view_name, request=self.context['request'])
 
 
 class HalModelSerializer(HyperlinkedModelSerializer):

--- a/drf_hal_json/serializers.py
+++ b/drf_hal_json/serializers.py
@@ -22,6 +22,12 @@ class HalListSerializer(ListSerializer):
         return ReturnDict(ret, serializer=self)
 
     def to_representation(self, collection):
+        # cribbed from HyperlinkedRelatedField.to_representation
+        assert 'request' in self.context, (
+            "`%s` requires the request in the serializer"
+            " context. Add `context={'request': request}` when instantiating "
+            "the serializer." % self.__class__.__name__
+        )
         # Wrap the standard ListSerializer in _embedded and populate _links with the URL of the list
         return {
             LINKS_FIELD_NAME: {
@@ -42,7 +48,7 @@ class HalListSerializer(ListSerializer):
                 'model_name': model._meta.object_name.lower()
             }
         view_name = '{}-list'.format(base_name)
-        return reverse(view_name, request=self._context['request'])
+        return reverse(view_name, request=self.context['request'])
 
 
 class HalModelSerializer(HyperlinkedModelSerializer):

--- a/tests/testproject/serializers.py
+++ b/tests/testproject/serializers.py
@@ -1,13 +1,13 @@
 from drf_hal_json.fields import (HalContributeToLinkField, HalHyperlinkedIdentityField, HalHyperlinkedPropertyField,
                                  HalHyperlinkedRelatedField, HalHyperlinkedSerializerMethodField)
-from drf_hal_json.serializers import HalModelSerializer
+from drf_hal_json.serializers import HalModelSerializer, HalRelatedModelSerializer
 from rest_framework import serializers
 
 from .models import (AbundantResource, CustomResource, FileResource, RelatedResource1, RelatedResource2,
                      RelatedResource3, TestResource, URLResource)
 
 
-class RelatedResource1Serializer(HalModelSerializer):
+class RelatedResource1Serializer(HalRelatedModelSerializer):
     name = HalContributeToLinkField(place_on='self', property_name='title')
 
     class Meta:

--- a/tests/testproject/serializers.py
+++ b/tests/testproject/serializers.py
@@ -1,13 +1,13 @@
 from drf_hal_json.fields import (HalContributeToLinkField, HalHyperlinkedIdentityField, HalHyperlinkedPropertyField,
                                  HalHyperlinkedRelatedField, HalHyperlinkedSerializerMethodField)
-from drf_hal_json.serializers import HalModelSerializer, HalRelatedModelSerializer
+from drf_hal_json.serializers import HalModelSerializer
 from rest_framework import serializers
 
 from .models import (AbundantResource, CustomResource, FileResource, RelatedResource1, RelatedResource2,
                      RelatedResource3, TestResource, URLResource)
 
 
-class RelatedResource1Serializer(HalRelatedModelSerializer):
+class RelatedResource1Serializer(HalModelSerializer):
     name = HalContributeToLinkField(place_on='self', property_name='title')
 
     class Meta:

--- a/tests/testproject/tests.py
+++ b/tests/testproject/tests.py
@@ -121,6 +121,15 @@ class HalTest(TestCase):
         self.assertIn("next", pages["_links"])
         next_link = pages["_links"]["next"]["href"]
 
+        unpaged = self.client.get("/abundant-unpaged/").data
+        # Renders with _links and _embedded
+        self.assertIn("_links", unpaged)
+        self.assertIn("_embedded", unpaged)
+        self.assertIn("self", unpaged["_links"])
+        # Includes no pages
+        self.assertNotIn("previous", unpaged["_links"])
+        self.assertNotIn("next", unpaged["_links"])
+
         pages = self.client.get(next_link).data
         self.assertIn("self", pages["_links"])
         self.assertIn("previous", pages["_links"])

--- a/tests/testproject/urls.py
+++ b/tests/testproject/urls.py
@@ -4,7 +4,7 @@ from rest_framework.routers import DefaultRouter
 from .views import (AbundantResourceViewSet, CustomResourceViewSet,
                     RelatedResource1ViewSet, RelatedResource2ViewSet,
                     RelatedResource3ViewSet, TestResourceViewSet,
-                    URLResourceViewSet, FileResourceViewSet)
+                    URLResourceViewSet, FileResourceViewSet, AbundantUnpagedViewSet)
 
 router = DefaultRouter()
 router.register(r'test-resources', TestResourceViewSet)
@@ -13,6 +13,7 @@ router.register(r'related-resources-2', RelatedResource2ViewSet)
 router.register(r'related-resources-3', RelatedResource3ViewSet)
 router.register(r'custom-resources', CustomResourceViewSet)
 router.register(r'abundant-resources', AbundantResourceViewSet)
+router.register(r'abundant-unpaged', AbundantUnpagedViewSet)
 router.register(r'url-resources', URLResourceViewSet)
 router.register(r'file-resources', FileResourceViewSet)
 urlpatterns = router.urls

--- a/tests/testproject/views.py
+++ b/tests/testproject/views.py
@@ -43,6 +43,10 @@ class AbundantResourceViewSet(HalCreateModelMixin, ModelViewSet):
     queryset = AbundantResource.objects.all()
 
 
+class AbundantUnpagedViewSet(AbundantResourceViewSet):
+    pagination_class = None
+
+
 class URLResourceViewSet(HalCreateModelMixin, ModelViewSet):
     serializer_class = HyperlinkedPropertySerializer
     queryset = URLResource.objects.all()


### PR DESCRIPTION
This PR adds HAL-compliant list serialization to HalModelSerializers:

 - Add `HalListSerializer` (inherits from `ListSerializer`) to generate HAL-compliant output.
     - this only happens in calls to `.data` to avoid poisoning list of related objects
 - Update `HalModelSerializer` to use `HalListSerializer` by default (`__new__` calls `many_init` so the change is found here)

This PR is not as clean as I'd like:

 - Unfortunately, the default list serializer is hard coded in `BaseSerializer.many_init` so I had to conditionally inject the new default in `Meta.list_serializer_class`.
     - Ideally, the `default_list_serializer` logic (or something similar) would be pushed up to DRF's BaseSerializer so we could just set a new default in this class.
 - There is no existing infrastructure for resolving the list view for a model
     - `HalListSerializer.build_view_url` parrots the approach found in DRF (smeared over a bunch of helper functions)
     - I introduced a new `Meta` attribute (i.e. `base_name`) to support manual override
     - DRF might accept `base_name` (or something similar) since it would support both `-list` and `-detail`.

I'm not going to actually suggest anything to DRF until the collaborators here are satisfied with the approach.

EDIT: Updated to reflect latest code.