### PR TITLE
Suppress property fields if falesy

### DIFF
--- a/drf_hal_json/serializers.py
+++ b/drf_hal_json/serializers.py
@@ -44,7 +44,7 @@ class HalModelSerializer(HyperlinkedModelSerializer):
                 resp[LINKS_FIELD_NAME][field_name] = self.build_link_object(val)
                 for property_name in self.link_property_fields.get(field_name, []):
                     prop = ret.pop(self.link_property_fields[field_name][property_name])
-                    if prop:
+                    if prop is not None:
                         resp[LINKS_FIELD_NAME][field_name][property_name] = prop
 
         for field_name in self.embedded_field_names:

--- a/drf_hal_json/serializers.py
+++ b/drf_hal_json/serializers.py
@@ -44,7 +44,8 @@ class HalModelSerializer(HyperlinkedModelSerializer):
                 resp[LINKS_FIELD_NAME][field_name] = self.build_link_object(val)
                 for property_name in self.link_property_fields.get(field_name, []):
                     prop = ret.pop(self.link_property_fields[field_name][property_name])
-                    resp[LINKS_FIELD_NAME][field_name][property_name] = prop
+                    if prop:
+                        resp[LINKS_FIELD_NAME][field_name][property_name] = prop
 
         for field_name in self.embedded_field_names:
             # if a related resource is embedded, it should still

--- a/tests/testproject/serializers.py
+++ b/tests/testproject/serializers.py
@@ -104,10 +104,11 @@ class FileSerializer(HalModelSerializer):
     self_title = HalContributeToLinkField(place_on='self')
     file_title = HalContributeToLinkField(place_on='file')
     file_type = HalContributeToLinkField(place_on='file', property_name='type')
+    self_none = HalContributeToLinkField(place_on='self', property_name='none')
 
     class Meta:
         model = FileResource
-        fields = ('self', 'self_title', 'file', 'file_title', 'file_type', 'image')
+        fields = ('self', 'self_title', 'file', 'file_title', 'file_type', 'image', 'self_none')
 
     def get_self_title(self, obj):
         return str(obj.pk)
@@ -117,3 +118,6 @@ class FileSerializer(HalModelSerializer):
 
     def get_file_type(self, obj):
         return 'application/zip'
+
+    def get_self_none(self, obj):
+        return None

--- a/tests/testproject/tests.py
+++ b/tests/testproject/tests.py
@@ -142,6 +142,9 @@ class HalTest(TestCase):
         self.assertIn("title", custom_resource_links['file'])
         self.assertEqual(custom_resource_links['file']['type'], "application/zip")
         self.assertIn("image", custom_resource_links)
+        self.assertIn("self", custom_resource_links)
+        # HalContributeToLinkField returning None should be suppressed
+        self.assertNotIn("none", custom_resource_links['self'])
 
     def test_serializer_method_link(self):
         resp = self.client.get("/custom-resources/1/")


### PR DESCRIPTION
Fixes #24.

While I originally suggested that we might raise an exception, I'm increasingly opposed to that approach.  At the moment, the [recommended approach](http://www.django-rest-framework.org/api-guide/serializers/#dynamically-modifying-fields) to conditionally remove fields is to change the field list during `__init__`.  However, the model is not available at this time so invalid fields cannot be excluded.

Nor do the other best practices (like multiple serializers) appear feasible in the face of exponentially many possible variants (2 ^ number of optional attributes).

edit:  I've realized that this field cannot be used in the way I originally intended, but I still believe that excluding None is appropriate for the conditional reasons explained above.