### PR TITLE
Limit _links to only Hal* fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,6 @@ Pagination is supported and will produce `next` and `previous` links.
 Model-level relations are both `_linked` and `_embedded` per default. For only
 linking, use `HalHyperlinkedRelatedField` in the serializer.
 
-Django `FileField` and `ImageField` fields are automatically rendered as links.
-
 ## Example ##
 
 Serializer:
@@ -127,6 +125,7 @@ added.
 from drf_hal_json.fields import HalContributeToLinkField
 
 class FileSerializer(HalModelSerializer):
+    file = HalHyperlinkedRelatedField()
     file_title = HalContributeToLinkField(place_on='file')
     file_type = HalContributeToLinkField(place_on='file', property_name='type')
 
@@ -140,9 +139,6 @@ class FileSerializer(HalModelSerializer):
     def get_file_type(self, obj):
         return 'application/zip'
 ```
-
-In the above example, we ride on the fact that Django `FileField`
-and `ImageField` fields are automatically rendered as links.
 
 `HalContributeToLinkField` can be used for any model-level relation
 which are not explicitly linked using `HalHyperlinkedRelatedField`.

--- a/README.md
+++ b/README.md
@@ -140,6 +140,10 @@ class FileSerializer(HalModelSerializer):
         return 'application/zip'
 ```
 
+See the implementation of `HalFileField` to see how a URL-producing
+serializer (by default `FileField` serializes to a URL) can be included
+in `_links`.
+
 `HalContributeToLinkField` can be used for any model-level relation
 which are not explicitly linked using `HalHyperlinkedRelatedField`.
 In this case, `HalContributeToLinkField` can be used to adorn the `self`

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ added.
 from drf_hal_json.fields import HalContributeToLinkField
 
 class FileSerializer(HalModelSerializer):
-    file = HalHyperlinkedRelatedField()
+    file = HalFileField()
     file_title = HalContributeToLinkField(place_on='file')
     file_type = HalContributeToLinkField(place_on='file', property_name='type')
 

--- a/drf_hal_json/fields.py
+++ b/drf_hal_json/fields.py
@@ -2,7 +2,12 @@ from rest_framework import serializers
 from rest_framework.relations import Hyperlink
 
 
-class HalHyperlinkedPropertyField(serializers.Field):
+class HalIncludeInLinksMixin(object):
+    """Mixin to flag a field as needing included in the _links section"""
+    pass
+
+
+class HalHyperlinkedPropertyField(HalIncludeInLinksMixin, serializers.Field):
     process_value = None
 
     def __init__(self, **kwargs):
@@ -19,7 +24,8 @@ class HalHyperlinkedPropertyField(serializers.Field):
     def to_internal_value(self, data):
         raise NotImplementedError()
 
-class HalHyperlinkedSerializerMethodField(serializers.SerializerMethodField):
+
+class HalHyperlinkedSerializerMethodField(HalIncludeInLinksMixin, serializers.SerializerMethodField):
     def __init__(self, **kwargs):
         super(HalHyperlinkedSerializerMethodField, self).__init__(**kwargs)
 
@@ -39,7 +45,7 @@ class HalContributeToLinkField(serializers.SerializerMethodField):
         super(HalContributeToLinkField, self).__init__(**kwargs)
 
 
-class HalHyperlinkedRelatedField(serializers.HyperlinkedRelatedField):
+class HalHyperlinkedRelatedField(HalIncludeInLinksMixin, serializers.HyperlinkedRelatedField):
 
     def __init__(self, **kwargs):
         self.title_field = kwargs.pop('title_field', None)
@@ -70,7 +76,7 @@ class HalHyperlinkedRelatedField(serializers.HyperlinkedRelatedField):
         return val
 
 
-class HalHyperlinkedIdentityField(serializers.HyperlinkedIdentityField):
+class HalHyperlinkedIdentityField(HalIncludeInLinksMixin, serializers.HyperlinkedIdentityField):
 
     def __init__(self, **kwargs):
         self.title_field = kwargs.pop('title_field', None)
@@ -99,3 +105,7 @@ class HalHyperlinkedIdentityField(serializers.HyperlinkedIdentityField):
             val['name'] = getattr(instance, self.name_field)
 
         return val
+
+
+class HalFileField(HalIncludeInLinksMixin, serializers.FileField):
+    pass

--- a/drf_hal_json/serializers.py
+++ b/drf_hal_json/serializers.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 
 from drf_hal_json import EMBEDDED_FIELD_NAME, LINKS_FIELD_NAME, URL_FIELD_NAME
 from drf_hal_json.fields import HalContributeToLinkField, HalHyperlinkedRelatedField, HalHyperlinkedIdentityField, \
-    HalIncludeInLinksMixin, HalHyperlinkedPropertyField, HalHyperlinkedSerializerMethodField
+    HalIncludeInLinksMixin
 from rest_framework.fields import empty
 from rest_framework.relations import ManyRelatedField
 from rest_framework.serializers import BaseSerializer, HyperlinkedModelSerializer

--- a/drf_hal_json/serializers.py
+++ b/drf_hal_json/serializers.py
@@ -1,8 +1,8 @@
 from collections import defaultdict
 
 from drf_hal_json import EMBEDDED_FIELD_NAME, LINKS_FIELD_NAME, URL_FIELD_NAME
-from drf_hal_json.fields import HalHyperlinkedPropertyField, HalContributeToLinkField, \
-    HalHyperlinkedSerializerMethodField, HalHyperlinkedRelatedField, HalHyperlinkedIdentityField
+from drf_hal_json.fields import HalContributeToLinkField, HalHyperlinkedRelatedField, HalHyperlinkedIdentityField, \
+    HalIncludeInLinksMixin, HalHyperlinkedPropertyField, HalHyperlinkedSerializerMethodField
 from rest_framework.fields import empty
 from rest_framework.relations import ManyRelatedField
 from rest_framework.serializers import BaseSerializer, HyperlinkedModelSerializer
@@ -83,12 +83,7 @@ class HalModelSerializer(HyperlinkedModelSerializer):
         # ManyRelatedField could wrap any type so we need to analyze the underlying type
         if isinstance(field, ManyRelatedField):
             field = field.child_relation
-        return (
-            isinstance(field, HalHyperlinkedRelatedField) or
-            isinstance(field, HalHyperlinkedIdentityField) or
-            isinstance(field, HalHyperlinkedPropertyField) or
-            isinstance(field, HalHyperlinkedSerializerMethodField)
-        )
+        return isinstance(field, HalIncludeInLinksMixin)
 
     @staticmethod
     def _is_link_contribution_field(field):

--- a/tests/testproject/migrations/0001_initial.py
+++ b/tests/testproject/migrations/0001_initial.py
@@ -94,4 +94,11 @@ class Migration(migrations.Migration):
             name='related_resource_3',
             field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='testproject.RelatedResource3'),
         ),
+        migrations.CreateModel(
+            name='SlugRelatedResource',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('slug_related', models.ManyToManyField(to='testproject.TestResource')),
+            ],
+        ),
     ]

--- a/tests/testproject/models.py
+++ b/tests/testproject/models.py
@@ -38,6 +38,10 @@ class CustomResource(models.Model):
     name = models.CharField(max_length=255)
 
 
+class SlugRelatedResource(models.Model):
+    slug_related = models.ManyToManyField(TestResource)
+
+
 class AbundantResource(models.Model):
     created = models.DateTimeField(auto_now=True)
     name = models.CharField(max_length=255)
@@ -49,5 +53,5 @@ class URLResource(models.Model):
 
 
 class FileResource(models.Model):
-    file = models.FileField(max_length=255)
-    image = models.ImageField(max_length=255)
+    file = models.FileField(max_length=255, upload_to='./tmp')
+    image = models.ImageField(max_length=255, upload_to='./tmp')

--- a/tests/testproject/serializers.py
+++ b/tests/testproject/serializers.py
@@ -1,10 +1,11 @@
+from rest_framework.relations import SlugRelatedField
+
 from drf_hal_json.fields import (HalContributeToLinkField, HalHyperlinkedIdentityField, HalHyperlinkedPropertyField,
                                  HalHyperlinkedRelatedField, HalHyperlinkedSerializerMethodField)
 from drf_hal_json.serializers import HalModelSerializer
-from rest_framework import serializers
 
 from .models import (AbundantResource, CustomResource, FileResource, RelatedResource1, RelatedResource2,
-                     RelatedResource3, TestResource, URLResource)
+                     RelatedResource3, TestResource, URLResource, SlugRelatedResource)
 
 
 class RelatedResource1Serializer(HalModelSerializer):
@@ -26,7 +27,7 @@ class RelatedResource1NoSelfSerializer(RelatedResource1Serializer):
 
 class RelatedResource2Serializer(HalModelSerializer):
     # These related resources are not embedded, just linked
-    related_resources = serializers.HyperlinkedRelatedField(
+    related_resources = HalHyperlinkedRelatedField(
         many=True, read_only=True, view_name='relatedresource1-detail',
         source='related_resources_1')
     related_resources_1 = HalHyperlinkedRelatedField(
@@ -71,6 +72,14 @@ class CustomResourceSerializer(HalModelSerializer):
 
     def get_custom_link(self, obj):
         return 'http://www.example.com'
+
+
+class SlugRelatedResourceSerializer(HalModelSerializer):
+    class Meta:
+        model = SlugRelatedResource
+        fields = ('self', 'slug_related')
+
+    slug_related = SlugRelatedField(slug_field='name', read_only=True)
 
 
 class AbundantResourceSerializer(HalModelSerializer):

--- a/tests/testproject/serializers.py
+++ b/tests/testproject/serializers.py
@@ -1,7 +1,7 @@
 from rest_framework.relations import SlugRelatedField
 
 from drf_hal_json.fields import (HalContributeToLinkField, HalHyperlinkedIdentityField, HalHyperlinkedPropertyField,
-                                 HalHyperlinkedRelatedField, HalHyperlinkedSerializerMethodField)
+                                 HalHyperlinkedRelatedField, HalHyperlinkedSerializerMethodField, HalFileField)
 from drf_hal_json.serializers import HalModelSerializer
 
 from .models import (AbundantResource, CustomResource, FileResource, RelatedResource1, RelatedResource2,
@@ -130,3 +130,19 @@ class FileSerializer(HalModelSerializer):
 
     def get_self_none(self, obj):
         return None
+
+
+class HalFileSerializer(HalModelSerializer):
+    file = HalFileField()
+    file_title = HalContributeToLinkField(place_on='file')
+    file_type = HalContributeToLinkField(place_on='file', property_name='type')
+
+    class Meta:
+        model = FileResource
+        fields = ('file', 'file_title', 'file_type')
+
+    def get_file_title(self, obj):
+        return str(obj.pk)
+
+    def get_file_type(self, obj):
+        return 'application/zip'

--- a/tests/testproject/tests.py
+++ b/tests/testproject/tests.py
@@ -4,7 +4,7 @@ from drf_hal_json import EMBEDDED_FIELD_NAME, LINKS_FIELD_NAME
 from rest_framework.reverse import reverse
 
 from .models import (AbundantResource, CustomResource, FileResource, RelatedResource1, RelatedResource2,
-                     RelatedResource3, TestResource, URLResource)
+                     RelatedResource3, TestResource, URLResource, SlugRelatedResource)
 
 
 class HalTest(TestCase):
@@ -34,6 +34,10 @@ class HalTest(TestCase):
         self.file_resource = FileResource()
         self.file_resource.file.save('foo', ContentFile(b'bar'))
         self.file_resource.image.save('image', ContentFile(b'JPEG'))
+        self.slug_resource = SlugRelatedResource()
+        self.slug_resource.save()
+        self.slug_resource.slug_related.add(self.test_resource_1)
+        self.slug_resource.save()
 
         for i in range(0, 50):
             AbundantResource.objects.create(name="Abundant Resource {}".format(i))
@@ -42,7 +46,10 @@ class HalTest(TestCase):
         resp = self.client.get("/test-resources/1/")
         self.assertEqual(200, resp.status_code, resp.content)
         test_resource_data = resp.data
-        self.assertEqual(4, len(test_resource_data))
+        self.assertEqual(
+            {'_embedded', '_links', 'id', 'name'},
+            set(test_resource_data.keys())
+        )
         self.assertEqual(self.test_resource_1.id, test_resource_data['id'])
         self.assertEqual(self.test_resource_1.name, test_resource_data['name'])
 
@@ -50,7 +57,10 @@ class HalTest(TestCase):
         resp = self.client.get("/test-resources/1/")
 
         test_resource_links = resp.data[LINKS_FIELD_NAME]
-        self.assertEqual(3, len(test_resource_links))
+        self.assertEqual(
+            {'self', 'related_resource_2', 'related_resource_1'},
+            set(test_resource_links.keys())
+        )
         self.assertEqual(self.TESTSERVER_URL + reverse('testresource-detail', kwargs={'pk': self.test_resource_1.id}),
                          test_resource_links['self']['href'])
         self.assertEqual(
@@ -64,7 +74,10 @@ class HalTest(TestCase):
         resp = self.client.get("/test-resources/1/")
         test_resource_data = resp.data
         related_resource_2_data = test_resource_data[EMBEDDED_FIELD_NAME]['related_resource_2']
-        self.assertEqual(5, len(related_resource_2_data))
+        self.assertEqual(
+            {'active', '_links', '_embedded', 'name', 'id'},
+            set(related_resource_2_data.keys())
+        )
         self.assertEqual(self.related_resource_2.name, related_resource_2_data['name'])
 
     def test_embedded_resource_links(self):
@@ -72,13 +85,17 @@ class HalTest(TestCase):
         test_resource_data = resp.data
         related_resource_2_data = test_resource_data[EMBEDDED_FIELD_NAME]['related_resource_2']
         related_resource_2_links = related_resource_2_data[LINKS_FIELD_NAME]
-        self.assertEqual(3, len(related_resource_2_links))
+        self.assertEqual(
+            {'related_resources_1', 'self', 'related_resources'},
+            set(related_resource_2_links.keys())
+        )
         self.assertEqual(
             self.TESTSERVER_URL + reverse('relatedresource2-detail', kwargs={'pk': self.related_resource_2.id}),
             related_resource_2_links['self']['href'])
 
     def test_link_titles(self):
         resp = self.client.get("/related-resources-2/1/")
+        self.assertIn('related_resources_1', resp.data[LINKS_FIELD_NAME])
         related = resp.data[LINKS_FIELD_NAME]['related_resources_1']
         self.assertEqual(2, len(related))
         self.assertEqual('Nested-Related-Resource11', related[0]['title'])
@@ -87,7 +104,10 @@ class HalTest(TestCase):
     def test_custom_lookup_field(self):
         resp = self.client.get("/custom-resources/1/")
         custom_resource_links = resp.data[LINKS_FIELD_NAME]
-        self.assertEqual(3, len(custom_resource_links))
+        self.assertEqual(
+            {'self', 'related_resource_3', 'custom_link'},
+            set(custom_resource_links.keys())
+        )
         self.assertEqual(
             self.TESTSERVER_URL + reverse("customresource-detail", kwargs={"pk": self.custom_resource_1.id}),
             custom_resource_links["self"]["href"])
@@ -109,22 +129,31 @@ class HalTest(TestCase):
         self.assertEqual(self.TESTSERVER_URL + '/example/?foo=bar',
                          custom_resource_links["url_rel_processed"]["href"])
 
+    def test_slug(self):
+        slug = self.client.get("/slug-resources/1/").data
+        print(slug)
+        self.assertEqual(
+            {LINKS_FIELD_NAME, 'slug_related'},
+            set(slug.keys())
+        )
+        self.assertNotIn('slug_related', slug[LINKS_FIELD_NAME])
+
     def test_pagination(self):
         no_pages = self.client.get("/test-resources/").data
-        self.assertIn("self", no_pages["_links"])
-        self.assertNotIn("previous", no_pages["_links"])
-        self.assertNotIn("next", no_pages["_links"])
+        self.assertIn("self", no_pages[LINKS_FIELD_NAME])
+        self.assertNotIn("previous", no_pages[LINKS_FIELD_NAME])
+        self.assertNotIn("next", no_pages[LINKS_FIELD_NAME])
 
         pages = self.client.get("/abundant-resources/").data
-        self.assertIn("self", pages["_links"])
-        self.assertNotIn("previous", pages["_links"])
-        self.assertIn("next", pages["_links"])
-        next_link = pages["_links"]["next"]["href"]
+        self.assertIn("self", pages[LINKS_FIELD_NAME])
+        self.assertNotIn("previous", pages[LINKS_FIELD_NAME])
+        self.assertIn("next", pages[LINKS_FIELD_NAME])
+        next_link = pages[LINKS_FIELD_NAME]["next"]["href"]
 
         pages = self.client.get(next_link).data
-        self.assertIn("self", pages["_links"])
-        self.assertIn("previous", pages["_links"])
-        self.assertIn("next", pages["_links"])
+        self.assertIn("self", pages[LINKS_FIELD_NAME])
+        self.assertIn("previous", pages[LINKS_FIELD_NAME])
+        self.assertIn("next", pages[LINKS_FIELD_NAME])
 
     def test_empty_relation(self):
         resp = self.client.get("/custom-resources/1/")

--- a/tests/testproject/tests.py
+++ b/tests/testproject/tests.py
@@ -172,6 +172,18 @@ class HalTest(TestCase):
         self.assertNotIn("none", custom_resource_links['self'],
                          msg="HalContributeToLinkField returning None should be suppressed")
 
+    def test_readme_contribute_example(self):
+        resp = self.client.get("/hal-file-resources/1/")
+        custom_resource_links = resp.data[LINKS_FIELD_NAME]
+        self.assertIn("file", custom_resource_links,
+                      msg='HalFileField should be included in _links')
+        self.assertIn("title", custom_resource_links['file'],
+                      msg='HalContributeToLinkField should have been included in _links.file')
+        self.assertIn("type", custom_resource_links['file'],
+                      msg='HalContributeToLinkField should have been included in _links.file')
+        self.assertEqual(custom_resource_links['file']['type'], "application/zip",
+                         msg='_links.file.type should equal static return of get_file_type (i.e. "application/zip")')
+
     def test_serializer_method_link(self):
         resp = self.client.get("/custom-resources/1/")
         custom_resource_links = resp.data[LINKS_FIELD_NAME]

--- a/tests/testproject/tests.py
+++ b/tests/testproject/tests.py
@@ -167,13 +167,10 @@ class HalTest(TestCase):
     def test_filefield_serialization(self):
         resp = self.client.get("/file-resources/1/")
         custom_resource_links = resp.data[LINKS_FIELD_NAME]
-        self.assertIn("file", custom_resource_links)
-        self.assertIn("title", custom_resource_links['file'])
-        self.assertEqual(custom_resource_links['file']['type'], "application/zip")
-        self.assertIn("image", custom_resource_links)
-        self.assertIn("self", custom_resource_links)
-        # HalContributeToLinkField returning None should be suppressed
-        self.assertNotIn("none", custom_resource_links['self'])
+        self.assertNotIn("file", custom_resource_links,
+                         msg="basic FileFields should not be included in links")
+        self.assertNotIn("none", custom_resource_links['self'],
+                         msg="HalContributeToLinkField returning None should be suppressed")
 
     def test_serializer_method_link(self):
         resp = self.client.get("/custom-resources/1/")

--- a/tests/testproject/urls.py
+++ b/tests/testproject/urls.py
@@ -4,7 +4,7 @@ from rest_framework.routers import DefaultRouter
 from .views import (AbundantResourceViewSet, CustomResourceViewSet,
                     RelatedResource1ViewSet, RelatedResource2ViewSet,
                     RelatedResource3ViewSet, TestResourceViewSet,
-                    URLResourceViewSet, FileResourceViewSet)
+                    URLResourceViewSet, FileResourceViewSet, SlugRelatedResourceViewSet)
 
 router = DefaultRouter()
 router.register(r'test-resources', TestResourceViewSet)
@@ -12,6 +12,7 @@ router.register(r'related-resources-1', RelatedResource1ViewSet)
 router.register(r'related-resources-2', RelatedResource2ViewSet)
 router.register(r'related-resources-3', RelatedResource3ViewSet)
 router.register(r'custom-resources', CustomResourceViewSet)
+router.register(r'slug-resources', SlugRelatedResourceViewSet)
 router.register(r'abundant-resources', AbundantResourceViewSet)
 router.register(r'url-resources', URLResourceViewSet)
 router.register(r'file-resources', FileResourceViewSet)

--- a/tests/testproject/urls.py
+++ b/tests/testproject/urls.py
@@ -4,7 +4,8 @@ from rest_framework.routers import DefaultRouter
 from .views import (AbundantResourceViewSet, CustomResourceViewSet,
                     RelatedResource1ViewSet, RelatedResource2ViewSet,
                     RelatedResource3ViewSet, TestResourceViewSet,
-                    URLResourceViewSet, FileResourceViewSet, SlugRelatedResourceViewSet)
+                    URLResourceViewSet, FileResourceViewSet,
+                    SlugRelatedResourceViewSet, HalFileResourceViewSet)
 
 router = DefaultRouter()
 router.register(r'test-resources', TestResourceViewSet)
@@ -16,4 +17,5 @@ router.register(r'slug-resources', SlugRelatedResourceViewSet)
 router.register(r'abundant-resources', AbundantResourceViewSet)
 router.register(r'url-resources', URLResourceViewSet)
 router.register(r'file-resources', FileResourceViewSet)
+router.register(r'hal-file-resources', HalFileResourceViewSet)
 urlpatterns = router.urls

--- a/tests/testproject/views.py
+++ b/tests/testproject/views.py
@@ -3,13 +3,13 @@ from rest_framework.viewsets import ModelViewSet
 
 from .models import (AbundantResource, CustomResource, RelatedResource1,
                      RelatedResource2, RelatedResource3, TestResource,
-                     URLResource, FileResource)
+                     URLResource, FileResource, SlugRelatedResource)
 from .serializers import (AbundantResourceSerializer, CustomResourceSerializer,
                           HyperlinkedPropertySerializer,
                           RelatedResource1Serializer,
                           RelatedResource2Serializer,
                           RelatedResource3Serializer, TestResourceSerializer,
-                          FileSerializer)
+                          FileSerializer, SlugRelatedResourceSerializer)
 
 
 class CustomResourceViewSet(HalCreateModelMixin, ModelViewSet):
@@ -36,6 +36,11 @@ class RelatedResource3ViewSet(HalCreateModelMixin, ModelViewSet):
     serializer_class = RelatedResource3Serializer
     queryset = RelatedResource3.objects.all()
     lookup_field = 'name'
+
+
+class SlugRelatedResourceViewSet(HalCreateModelMixin, ModelViewSet):
+    serializer_class = SlugRelatedResourceSerializer
+    queryset = SlugRelatedResource.objects.all()
 
 
 class AbundantResourceViewSet(HalCreateModelMixin, ModelViewSet):

--- a/tests/testproject/views.py
+++ b/tests/testproject/views.py
@@ -9,7 +9,7 @@ from .serializers import (AbundantResourceSerializer, CustomResourceSerializer,
                           RelatedResource1Serializer,
                           RelatedResource2Serializer,
                           RelatedResource3Serializer, TestResourceSerializer,
-                          FileSerializer, SlugRelatedResourceSerializer)
+                          FileSerializer, SlugRelatedResourceSerializer, HalFileSerializer)
 
 
 class CustomResourceViewSet(HalCreateModelMixin, ModelViewSet):
@@ -55,4 +55,9 @@ class URLResourceViewSet(HalCreateModelMixin, ModelViewSet):
 
 class FileResourceViewSet(HalCreateModelMixin, ModelViewSet):
     serializer_class = FileSerializer
+    queryset = FileResource.objects.all()
+
+
+class HalFileResourceViewSet(HalCreateModelMixin, ModelViewSet):
+    serializer_class = HalFileSerializer
     queryset = FileResource.objects.all()


### PR DESCRIPTION
Fixes #22.  Issue #22 specifically addressed the case where a `SlugRelatedField` was included in `_links` even thought it was a non-URL slug (like `name`).  When investigating this problem, it became clear that `HalModelSerializer` was making overly broad assumptions about the link-ness of stock DRF serializers.

For example, `test_filefield_serialization` verifies that a serialized `FileField` is put into `_links`.  While this is often the case, the [documentation](http://www.django-rest-framework.org/api-guide/fields/#filefield) states that `FileField` only returns a URL if `use_url` is true (and a `name` otherwise).  

Since it's valid to include a link in the body (but invalid to include a non-link in `_links`), this PR switches to the hyper-conservative assumption that only `Hal*` fields should be included in `_links`.  

 - Tests with non-`Hal*` fields were edited to use compliant `Hal*` fields.  
 - The `FileField` test case was left failing (I believe rightly so) as the basis of a broader discussion.  
 - Fields like `HyperlinkedIdentityField` need discussed.  On the one hand, a user can easily replace them with `HalHyperlinkedIdentityField` to move them to `_links`.  On the other, it's always a hyperlink.  Is there a use-case where it generates a link, but doesn't belong in `_links`?  Obviously, I have defaulted to the "safe" case, but don't object adding some additional fields if we're confident that they're safe.

To assist in writing the PR, the test suite was upgraded:

 - A case for the SlugRelatedField was added
 - Several tests were converted to check keys explicitly rather than count the length of a dict -- an unreliable way to check dict composition.
 - Temporary files built by the test cases have been relocated to `./tmp` for simpler cleanup (and possible `.gitignore`)