### PR TITLE
Test cases verifying symmetry of GET and PUT/POST

### DIFF
--- a/tests/testproject/tests.py
+++ b/tests/testproject/tests.py
@@ -1,5 +1,7 @@
 from django.core.files.base import ContentFile
 from django.test import TestCase
+from rest_framework.test import APIClient
+
 from drf_hal_json import EMBEDDED_FIELD_NAME, LINKS_FIELD_NAME
 from rest_framework.reverse import reverse
 
@@ -198,3 +200,45 @@ class HalTest(TestCase):
         custom_resource_links = resp.data[LINKS_FIELD_NAME]
         self.assertIn("custom_link", custom_resource_links)
         self.assertEqual("http://www.example.com", custom_resource_links["custom_link"]["href"])
+
+
+class GetPutSymmetry(TestCase):
+    client_class = APIClient
+
+    def setUp(self):
+        self.url_resource = URLResource.objects.create(
+            url_abs="https://www.example.com/",
+            url_rel="/example/")
+
+    def test_symmetric(self):
+        get = self.client.get("/url-resources/1/")
+        update = self.client.put(
+            "/url-resources/1/",
+            get.data,
+            content_type='application/hal+json'
+        )
+        self.assertEqual(
+            200,
+            update.status_code,
+        )
+
+
+class GetPostSymmetry(TestCase):
+    client_class = APIClient
+
+    def setUp(self):
+        self.url_resource = URLResource.objects.create(
+            url_abs="https://www.example.com/",
+            url_rel="/example/")
+
+    def test_symmetric(self):
+        get = self.client.get("/url-resources/1/")
+        update = self.client.post(
+            "/url-resources/",
+            get.data,
+            content_type='application/hal+json'
+        )
+        self.assertEqual(
+            201,
+            update.status_code,
+        )


### PR DESCRIPTION
This PR adds two test cases showing that GET and PUT/POST are not symmetric.  In the simplest case, I cannot PUT the payload of a GET to the same endpoint.  This occurs because GET returns a JSON object and PUT/POST seem to be looking for a stringified JSON object.

I'm happy to troubleshoot, but would like to solicit consensus that this is expected behavior before I dig too deep.  If anyone can recommend a place to start, that too would be appreciated.