### PR TITLE
Fix double href in HalHyperlinkedSerializerMethodField

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,4 +61,5 @@ target/
 .vscode
 tests/foo*
 tests/image*
+tests/tmp/
 *.orig

--- a/drf_hal_json/serializers.py
+++ b/drf_hal_json/serializers.py
@@ -1,13 +1,12 @@
 from collections import defaultdict
 
-from rest_framework.utils.serializer_helpers import ReturnDict
-
 from drf_hal_json import EMBEDDED_FIELD_NAME, LINKS_FIELD_NAME, URL_FIELD_NAME
 from drf_hal_json.fields import HalContributeToLinkField, HalHyperlinkedIdentityField, HalIncludeInLinksMixin
 from rest_framework.fields import empty
-from rest_framework.relations import ManyRelatedField, HyperlinkedRelatedField
+from rest_framework.relations import HyperlinkedRelatedField, ManyRelatedField
 from rest_framework.serializers import BaseSerializer, HyperlinkedModelSerializer, ListSerializer
 from rest_framework.utils.field_mapping import get_nested_relation_kwargs
+from rest_framework.utils.serializer_helpers import ReturnDict
 
 
 class HalListSerializer(ListSerializer):
@@ -62,7 +61,7 @@ class HalModelSerializer(HyperlinkedModelSerializer):
     def build_link_object(self, val):
         if (type([]) == type(val)):
             return [self.build_link_object(v) for v in val]
-        if isinstance(val, dict) and val.get('href', False):
+        if isinstance(val, dict) and 'href' in val:
             return val
         return {'href': val}
 

--- a/tests/testproject/serializers.py
+++ b/tests/testproject/serializers.py
@@ -1,11 +1,11 @@
+from drf_hal_json.fields import (HalContributeToLinkField, HalFileField, HalHyperlinkedIdentityField,
+                                 HalHyperlinkedPropertyField, HalHyperlinkedRelatedField,
+                                 HalHyperlinkedSerializerMethodField)
+from drf_hal_json.serializers import HalModelSerializer
 from rest_framework.relations import SlugRelatedField
 
-from drf_hal_json.fields import (HalContributeToLinkField, HalHyperlinkedIdentityField, HalHyperlinkedPropertyField,
-                                 HalHyperlinkedRelatedField, HalHyperlinkedSerializerMethodField, HalFileField)
-from drf_hal_json.serializers import HalModelSerializer
-
 from .models import (AbundantResource, CustomResource, FileResource, RelatedResource1, RelatedResource2,
-                     RelatedResource3, TestResource, URLResource, SlugRelatedResource)
+                     RelatedResource3, SlugRelatedResource, TestResource, URLResource)
 
 
 class RelatedResource1Serializer(HalModelSerializer):
@@ -61,17 +61,28 @@ class CustomResourceSerializer(HalModelSerializer):
     related_resource_3 = HalHyperlinkedIdentityField(
         read_only=True, view_name='relatedresource3-detail', lookup_field='name')
     custom_link = HalHyperlinkedSerializerMethodField()
+    custom_link_empty = HalHyperlinkedSerializerMethodField()
     name = HalContributeToLinkField(place_on='related_resource_3', property_name='title')
 
     class Meta:
         model = CustomResource
-        fields = ('self', 'name', 'related_resource_2', 'related_resource_3', 'custom_link')
+        fields = (
+            'self',
+            'name',
+            'related_resource_2',
+            'related_resource_3',
+            'custom_link',
+            'custom_link_empty',
+        )
 
     def get_name(self, obj):
         return obj.name
 
     def get_custom_link(self, obj):
         return 'http://www.example.com'
+
+    def get_custom_link_empty(self, obj):
+        return None
 
 
 class SlugRelatedResourceSerializer(HalModelSerializer):

--- a/tests/testproject/tests.py
+++ b/tests/testproject/tests.py
@@ -4,7 +4,7 @@ from drf_hal_json import EMBEDDED_FIELD_NAME, LINKS_FIELD_NAME
 from rest_framework.reverse import reverse
 
 from .models import (AbundantResource, CustomResource, FileResource, RelatedResource1, RelatedResource2,
-                     RelatedResource3, TestResource, URLResource, SlugRelatedResource)
+                     RelatedResource3, SlugRelatedResource, TestResource, URLResource)
 
 
 class HalTest(TestCase):
@@ -105,7 +105,7 @@ class HalTest(TestCase):
         resp = self.client.get("/custom-resources/1/")
         custom_resource_links = resp.data[LINKS_FIELD_NAME]
         self.assertEqual(
-            {'self', 'related_resource_3', 'custom_link'},
+            {'self', 'related_resource_3', 'custom_link', 'custom_link_empty'},
             set(custom_resource_links.keys())
         )
         self.assertEqual(
@@ -198,3 +198,4 @@ class HalTest(TestCase):
         custom_resource_links = resp.data[LINKS_FIELD_NAME]
         self.assertIn("custom_link", custom_resource_links)
         self.assertEqual("http://www.example.com", custom_resource_links["custom_link"]["href"])
+        self.assertIsNone(custom_resource_links["custom_link_empty"]["href"])


### PR DESCRIPTION
When the value of a `HalHyperlinkedSerializerMethodField` is falsey (which I believe is a valid use case), then the serializer returns the following structure:

``` json
{
    "_links": {
        "<field_name>": {
            "href": {
                "href": null
            }
        }
    }
}
```

Expected:

``` json
{
    "_links": {
        "<field_name>": {
            "href": null
        }
    }
}
```

This change fixes this and adds a unit test.

The rest of the PR is automatic import reordering.