### PR TITLE
Control Embedded Behavior

### DIFF
--- a/drf_hal_json/fields.py
+++ b/drf_hal_json/fields.py
@@ -7,9 +7,8 @@ class HalIncludeInLinksMixin(object):
     pass
 
 
-class HalPromoteEmbeddedMixin(object):
+class HalPromoteEmbeddedMixin(serializers.BaseSerializer):
     """Mixin to flag a field that should be serialized on the top level of its parent instead of embedded"""
-    pass
 
 
 class HalHyperlinkedPropertyField(HalIncludeInLinksMixin, serializers.Field):

--- a/drf_hal_json/fields.py
+++ b/drf_hal_json/fields.py
@@ -7,6 +7,11 @@ class HalIncludeInLinksMixin(object):
     pass
 
 
+class HalPromoteEmbeddedMixin(object):
+    """Mixin to flag a field that should be serialized on the top level of its parent instead of embedded"""
+    pass
+
+
 class HalHyperlinkedPropertyField(HalIncludeInLinksMixin, serializers.Field):
     process_value = None
 

--- a/drf_hal_json/serializers.py
+++ b/drf_hal_json/serializers.py
@@ -1,7 +1,8 @@
 from collections import defaultdict
 
 from drf_hal_json import EMBEDDED_FIELD_NAME, LINKS_FIELD_NAME, URL_FIELD_NAME
-from drf_hal_json.fields import HalContributeToLinkField, HalHyperlinkedIdentityField, HalIncludeInLinksMixin
+from drf_hal_json.fields import HalContributeToLinkField, HalHyperlinkedIdentityField, HalIncludeInLinksMixin, \
+    HalPromoteEmbeddedMixin
 from rest_framework.fields import empty
 from rest_framework.relations import HyperlinkedRelatedField, ManyRelatedField
 from rest_framework.serializers import BaseSerializer, HyperlinkedModelSerializer, ListSerializer
@@ -127,7 +128,7 @@ class HalModelSerializer(HyperlinkedModelSerializer):
 
     @staticmethod
     def _is_embedded_field(field):
-        return isinstance(field, BaseSerializer)
+        return not isinstance(field, HalPromoteEmbeddedMixin) and isinstance(field, BaseSerializer)
 
     def build_nested_field(self, field_name, relation_info, nested_depth):
         """


### PR DESCRIPTION
By default, the `HalModelSerializer` classifies all nested `BaseSerializer` instances as embedded nested objects.  In reality, the REST representation need not align 1:1 with the database representation so it should be possible to override this behavior.

For example, I'm supporting a 3rd party data specification (HL7v3) which has a 1:many relationship between Patient and ID (i.e. each patient can have multiple IDs).  For indexing reasons, this means that IDs need to be in their own table, but they're not really intended as embedded objects (e.g. they aren't independently linkable).

This PR creates a `HalPromoteEmbeddedMixin` that can be added to a nested serializer to indicate that it should be stored at the top level of the representation (and not `_embedded`).

P.S. I really *wanted* to add a check to `__init__` to make sure the `Meta.list_serializer_class` also uses `HalPromoteEmbeddedMixin`.  If you don't add it in both places, the `many=True` serializer won't pick up the behavior.  The problem is (1) I don't want to raise an exception because you don't have to mess with it if you never use `many` and (2) we don't import `logging` anywhere in the package so I didn't have a standard pattern to follow.